### PR TITLE
fix: ffmpeg logs and remove non-public-folder path case

### DIFF
--- a/packages/ffmpeg/src/ffmpeg-exporter-server.ts
+++ b/packages/ffmpeg/src/ffmpeg-exporter-server.ts
@@ -154,10 +154,8 @@ export class FFmpegExporterServer {
       resolvedPath = assetPath.replace('/@fs', '');
     } else if (assetPath.startsWith('http')) {
       resolvedPath = assetPath;
-    } else if (assetPath.startsWith('/')) {
-      resolvedPath = path.join(this.settings.output, '../public', assetPath);
     } else {
-      resolvedPath = path.join(this.settings.output, '..', assetPath);
+      resolvedPath = path.join(this.settings.output, '../public', assetPath);
     }
     return resolvedPath;
   }

--- a/packages/ffmpeg/src/video-frame-extractor.ts
+++ b/packages/ffmpeg/src/video-frame-extractor.ts
@@ -92,7 +92,7 @@ export class VideoFrameExtractor {
     range?: [number, number],
     fps?: number,
   ) {
-    const args = [];
+    const args = ['-loglevel', 'error'];
 
     if (range) {
       args.push('-ss', range[0].toString(), '-to', range[1].toString());


### PR DESCRIPTION
A while back we added support for having videos and audios inside the project folder structure. This didn't work well and I don't think this option has any big advantages. 

Files for the video and audio tags should be put in the `/public` folder and can be referenced with or without a leading `/`.