### PR TITLE
Fix audios get quieter when there are many

### DIFF
--- a/packages/ffmpeg/src/ffmpeg-exporter-server.ts
+++ b/packages/ffmpeg/src/ffmpeg-exporter-server.ts
@@ -251,7 +251,7 @@ export class FFmpegExporterServer {
 
       command
         .complexFilter([
-          `amix=inputs=${this.audioFilenames.length}:duration=longest`,
+          `amix=inputs=${this.audioFilenames.length}:duration=longest:normalize=0`,
         ])
         .outputOptions(['-c:a', 'pcm_s16le'])
         .on('end', () => {


### PR DESCRIPTION
ffmpeg by default reduces the audio volume so when they are combined they can never clip. This is not really the desired behauvior in this use case though. I noticed my audios got quieter and quieter the more I added.