### PR TITLE
Strip query string from video URL for warning

### DIFF
--- a/packages/2d/src/lib/components/Video.ts
+++ b/packages/2d/src/lib/components/Video.ts
@@ -81,7 +81,9 @@ export class Video extends Media {
     super(props);
 
     // If the file is not mp4, warn.
-    if (!this.fullSource().endsWith('.mp4')) {
+    // strip the query string from the source
+    const src = this.fullSource().split('?')[0];
+    if (!src.endsWith('.mp4')) {
       console.warn(
         `WARNING: Video source is not an MP4 file. This may significantly slow down rendering: ${this.fullSource()}`,
       );


### PR DESCRIPTION
We use presigned URLs for video, and we keep seeing this warning even though I believe rendering is still doing just fine since they are .mp4 files. 