### PR TITLE
chore: temporarily remove debug logs

### DIFF
--- a/packages/core/src/app/Logger.ts
+++ b/packages/core/src/app/Logger.ts
@@ -158,10 +158,13 @@ export class Logger {
   }
 
   public debug(payload: string | LogPayload) {
+    // TODO: include again with logLevel option
+    /*
     console.debug(
       'debug log from browser process:',
       typeof payload === 'string' ? payload : payload.message,
     );
+    */
     this.logLevel(LogLevel.Debug, payload);
   }
 


### PR DESCRIPTION
When we release 0.4.4, this should be included as a quick fix. Currently, all debug logs are logged which is too much