### PR TITLE
fix: correctly cache rive animations

### DIFF
--- a/packages/2d/src/lib/components/Rive.ts
+++ b/packages/2d/src/lib/components/Rive.ts
@@ -82,12 +82,13 @@ export class Rive extends Asset {
 
   protected override async draw(context: CanvasRenderingContext2D) {
     this.drawShape(context);
-    const {rive, renderer, canvas, artboard, animation} = await this.rive();
-    const box = BBox.fromSizeCentered(this.computedSize());
 
     this.currentTime = this.time();
     const timeToAdvance = this.currentTime - this.lastTime;
     this.lastTime = this.currentTime;
+
+    const {rive, renderer, canvas, artboard, animation} = await this.rive();
+    const box = BBox.fromSizeCentered(this.computedSize());
 
     const renderPromise = new Promise<void>(resolve => {
       function renderLoop() {


### PR DESCRIPTION
similar to the video tag: calculating time before getting the rive element makes sure that the frame gets recalculated