### PR TITLE
fix: initial empty frame when duration less than one frame and play set to false

### DIFF
--- a/packages/2d/src/lib/utils/video/parser/segment.ts
+++ b/packages/2d/src/lib/utils/video/parser/segment.ts
@@ -56,7 +56,7 @@ export class Segment {
       const segmentDurationInSeconds =
         this.edit.segmentDuration /
         this.file.getInfo().videoTracks[0].movie_timescale;
-      const framesToFill = segmentDurationInSeconds * this.edit.fps;
+      const framesToFill = Math.ceil(segmentDurationInSeconds * this.edit.fps);
 
       const height = this.file.getInfo().videoTracks[0].track_height;
       const width = this.file.getInfo().videoTracks[0].track_width;


### PR DESCRIPTION
fixes #222 