### PR TITLE
feat: support textwrap balance

### DIFF
--- a/packages/2d/src/lib/components/Layout.ts
+++ b/packages/2d/src/lib/components/Layout.ts
@@ -996,8 +996,11 @@ export class Layout extends Node {
       const wrap = this.textWrap();
       if (typeof wrap === 'boolean') {
         this.element.style.whiteSpace = wrap ? 'normal' : 'nowrap';
-      } else {
+      } else if (wrap === 'pre') {
         this.element.style.whiteSpace = wrap;
+      } else if (wrap === 'balance') {
+        this.element.style.whiteSpace = 'normal';
+        this.element.style.textWrap = wrap;
       }
     }
   }

--- a/packages/2d/src/lib/partials/types.ts
+++ b/packages/2d/src/lib/partials/types.ts
@@ -25,7 +25,7 @@ export type FlexContent =
 
 export type FlexItems = 'center' | 'start' | 'end' | 'stretch' | 'baseline';
 
-export type TextWrap = boolean | 'pre';
+export type TextWrap = boolean | 'pre' | 'balance';
 
 export type LayoutMode = boolean | null;
 


### PR DESCRIPTION
this was requested on our discord server some time ago.

Here's what textWrap=true looks like:
<img width="1504" alt="Screenshot 2024-07-31 at 09 58 43" src="https://github.com/user-attachments/assets/3b4a5f9e-1c09-4f94-9667-5b076ab939bc">


Here's what textWrap="balance" looks like
<img width="1504" alt="Screenshot 2024-07-31 at 09 58 58" src="https://github.com/user-attachments/assets/88dce113-45d4-46f3-81eb-c9e04f0d3e1f">
