### PR TITLE
chore: revert "fix: load fonts before all layout computations"

### DIFF
--- a/packages/2d/src/lib/components/Layout.ts
+++ b/packages/2d/src/lib/components/Layout.ts
@@ -1,7 +1,6 @@
 import {
   BBox,
   boolLerp,
-  DependencyContext,
   InterpolationFunction,
   modify,
   Origin,
@@ -283,8 +282,6 @@ export class Layout extends Node {
   @defaultStyle('text-align')
   @signal()
   public declare readonly textAlign: SimpleSignal<CanvasTextAlign, this>;
-
-  protected fontLoaded: boolean = false;
 
   protected getX(): number {
     if (this.isLayoutRoot()) {
@@ -964,14 +961,6 @@ export class Layout extends Node {
 
   @computed()
   protected applyFont() {
-    if (!this.fontLoaded) {
-      DependencyContext.collectPromise(
-        (async () => {
-          await document.fonts?.ready;
-          this.fontLoaded = true;
-        })(),
-      );
-    }
     this.element.style.fontFamily = this.fontFamily.isInitial()
       ? ''
       : this.fontFamily();

--- a/packages/2d/src/lib/components/Txt.test.tsx
+++ b/packages/2d/src/lib/components/Txt.test.tsx
@@ -10,7 +10,6 @@ describe('Txt', () => {
 
   it('Handle plain text', () => {
     const node = (<Txt lineWidth={8}>test</Txt>) as Txt;
-    node.toPromise();
 
     const parseSpy = vi.spyOn(node as any, 'parseChildren');
     const leaf = node.childAs<TxtLeaf>(0);
@@ -39,7 +38,6 @@ describe('Txt', () => {
         Apple <Txt>Banana</Txt> Cherry
       </Txt>
     ) as Txt;
-    node.toPromise();
 
     const first = node.childAs<TxtLeaf>(0);
     const second = node.childAs<Txt>(1);

--- a/packages/2d/src/lib/components/TxtLeaf.ts
+++ b/packages/2d/src/lib/components/TxtLeaf.ts
@@ -61,9 +61,9 @@ export class TxtLeaf extends Shape {
   }
 
   protected override async draw(context: CanvasRenderingContext2D) {
+    await document.fonts?.ready;
     this.requestFontUpdate();
     this.applyStyle(context);
-    await document.fonts?.ready;
     this.applyText(context);
     context.font = this.styles.font;
     if ('letterSpacing' in context) {

--- a/packages/2d/src/lib/components/__tests__/clone.test.tsx
+++ b/packages/2d/src/lib/components/__tests__/clone.test.tsx
@@ -52,7 +52,6 @@ describe('clone', () => {
     const template = (
       <Circle lineWidth={8} startAngle={signal} end={0.5} />
     ) as Circle;
-    template.toPromise();
     const clone = template.snapshotClone({end: 0});
 
     expect(clone.lineWidth()).toBe(8);

--- a/packages/2d/src/lib/components/__tests__/state.test.tsx
+++ b/packages/2d/src/lib/components/__tests__/state.test.tsx
@@ -12,7 +12,6 @@ describe('state', () => {
     const circle = (
       <Circle lineWidth={8} startAngle={signal} end={0.5} />
     ) as Circle;
-    circle.toPromise();
     circle.save();
 
     circle.lineWidth(16);


### PR DESCRIPTION
this PR introduced warnings that we need to check first