### PR TITLE
chore: consistent type imports eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,6 +34,13 @@
         "ignoreRestSiblings": true
       }
     ],
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        "prefer": "type-imports",
+        "fixStyle": "separate-type-imports"
+      }
+    ],
     "@typescript-eslint/naming-convention": [
       "error",
       {

--- a/packages/2d/src/editor/NodeInspectorConfig.tsx
+++ b/packages/2d/src/editor/NodeInspectorConfig.tsx
@@ -1,11 +1,11 @@
 import {useComputed} from '@preact/signals';
+import type {PluginInspectorConfig} from '@revideo/ui';
 import {
   AutoField,
   Button,
   Group,
   Label,
   Pane,
-  PluginInspectorConfig,
   Separator,
   UnknownField,
   findAndOpenFirstUserFile,

--- a/packages/2d/src/editor/PreviewOverlayConfig.tsx
+++ b/packages/2d/src/editor/PreviewOverlayConfig.tsx
@@ -1,12 +1,12 @@
 import {Vector2} from '@revideo/core';
+import type {PluginOverlayConfig} from '@revideo/ui';
 import {
   MouseButton,
   OverlayWrapper,
-  PluginOverlayConfig,
   useViewportContext,
   useViewportMatrix,
 } from '@revideo/ui';
-import {ComponentChildren} from 'preact';
+import type {ComponentChildren} from 'preact';
 import {usePluginState} from './Provider';
 
 function Component({children}: {children?: ComponentChildren}) {

--- a/packages/2d/src/editor/Provider.tsx
+++ b/packages/2d/src/editor/Provider.tsx
@@ -1,14 +1,10 @@
-import {
-  ReadonlySignal,
-  Signal,
-  computed,
-  signal,
-  useSignalEffect,
-} from '@preact/signals';
-import {Scene2D} from '@revideo/2d';
+import type {ReadonlySignal, Signal} from '@preact/signals';
+import {computed, signal, useSignalEffect} from '@preact/signals';
+import type {Scene2D} from '@revideo/2d';
 import {SceneRenderEvent} from '@revideo/core';
 import {useApplication, useCurrentScene} from '@revideo/ui';
-import {ComponentChildren, createContext} from 'preact';
+import type {ComponentChildren} from 'preact';
+import {createContext} from 'preact';
 import {useContext, useMemo} from 'preact/hooks';
 
 export interface PluginState {

--- a/packages/2d/src/editor/SceneGraphTabConfig.tsx
+++ b/packages/2d/src/editor/SceneGraphTabConfig.tsx
@@ -1,9 +1,8 @@
+import type {PluginTabConfig, PluginTabProps} from '@revideo/ui';
 import {
   AccountTree,
   emphasize,
   Pane,
-  PluginTabConfig,
-  PluginTabProps,
   Tab,
   useApplication,
   usePanels,

--- a/packages/2d/src/editor/icons/IconMap.ts
+++ b/packages/2d/src/editor/icons/IconMap.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import {FunctionComponent} from 'preact';
+import type {FunctionComponent} from 'preact';
 import {CircleIcon} from './CircleIcon';
 import {CodeBlockIcon} from './CodeBlockIcon';
 import {CurveIcon} from './CurveIcon';

--- a/packages/2d/src/editor/tree/NodeElement.tsx
+++ b/packages/2d/src/editor/tree/NodeElement.tsx
@@ -1,5 +1,6 @@
 import {useComputed, useSignal, useSignalEffect} from '@preact/signals';
-import {NODE_NAME, Node} from '@revideo/2d';
+import type {Node} from '@revideo/2d';
+import {NODE_NAME} from '@revideo/2d';
 import {useRef} from 'preact/hooks';
 import {usePluginState} from '../Provider';
 import {IconMap} from '../icons/IconMap';

--- a/packages/2d/src/editor/tree/TreeElement.tsx
+++ b/packages/2d/src/editor/tree/TreeElement.tsx
@@ -1,8 +1,8 @@
-import {Signal} from '@preact/signals';
+import type {Signal} from '@preact/signals';
 import {Collapse, Toggle} from '@revideo/ui';
 import {clsx} from 'clsx';
-import {ComponentChildren, JSX} from 'preact';
-import {Ref} from 'preact/hooks';
+import type {ComponentChildren, JSX} from 'preact';
+import type {Ref} from 'preact/hooks';
 import styles from './index.module.scss';
 
 const DEPTH_VAR = '--depth';

--- a/packages/2d/src/editor/tree/TreeRoot.tsx
+++ b/packages/2d/src/editor/tree/TreeRoot.tsx
@@ -1,5 +1,5 @@
 import {clsx} from 'clsx';
-import {JSX} from 'preact';
+import type {JSX} from 'preact';
 import styles from './index.module.scss';
 
 export function TreeRoot({

--- a/packages/2d/src/lib/code/CodeCursor.ts
+++ b/packages/2d/src/lib/code/CodeCursor.ts
@@ -1,17 +1,13 @@
-import {
-  clampRemap,
-  Color,
-  map,
-  SerializedVector2,
-  unwrap,
-  Vector2,
-} from '@revideo/core';
-import {Code} from '../components';
-import {CodeFragment, parseCodeFragment} from './CodeFragment';
-import {CodeHighlighter} from './CodeHighlighter';
-import {CodeMetrics} from './CodeMetrics';
-import {CodePoint, CodeRange} from './CodeRange';
-import {CodeScope, isCodeScope} from './CodeScope';
+import type {SerializedVector2} from '@revideo/core';
+import {clampRemap, Color, map, unwrap, Vector2} from '@revideo/core';
+import type {Code} from '../components';
+import type {CodeFragment} from './CodeFragment';
+import {parseCodeFragment} from './CodeFragment';
+import type {CodeHighlighter} from './CodeHighlighter';
+import type {CodeMetrics} from './CodeMetrics';
+import type {CodePoint, CodeRange} from './CodeRange';
+import type {CodeScope} from './CodeScope';
+import {isCodeScope} from './CodeScope';
 import {isPointInCodeSelection} from './CodeSelection';
 
 export interface CodeFragmentDrawingInfo {

--- a/packages/2d/src/lib/code/CodeDiffer.ts
+++ b/packages/2d/src/lib/code/CodeDiffer.ts
@@ -1,5 +1,6 @@
-import {CodeScope, CodeTag, resolveScope} from './CodeScope';
-import {CodeTokenizer} from './CodeTokenizer';
+import type {CodeScope, CodeTag} from './CodeScope';
+import {resolveScope} from './CodeScope';
+import type {CodeTokenizer} from './CodeTokenizer';
 import {patienceDiff} from './diff';
 
 /**

--- a/packages/2d/src/lib/code/CodeFragment.ts
+++ b/packages/2d/src/lib/code/CodeFragment.ts
@@ -1,4 +1,5 @@
-import {CodeMetrics, isCodeMetrics, measureString} from './CodeMetrics';
+import type {CodeMetrics} from './CodeMetrics';
+import {isCodeMetrics, measureString} from './CodeMetrics';
 
 export interface CodeFragment {
   before: CodeMetrics;

--- a/packages/2d/src/lib/code/CodeScope.ts
+++ b/packages/2d/src/lib/code/CodeScope.ts
@@ -1,5 +1,6 @@
-import {SignalValue, unwrap} from '@revideo/core';
-import {PossibleCodeFragment} from './CodeFragment';
+import type {SignalValue} from '@revideo/core';
+import {unwrap} from '@revideo/core';
+import type {PossibleCodeFragment} from './CodeFragment';
 import {isCodeMetrics} from './CodeMetrics';
 
 export interface CodeScope {

--- a/packages/2d/src/lib/code/CodeSelection.ts
+++ b/packages/2d/src/lib/code/CodeSelection.ts
@@ -1,9 +1,5 @@
-import {
-  CodePoint,
-  CodeRange,
-  isCodeRange,
-  isPointInCodeRange,
-} from './CodeRange';
+import type {CodePoint, CodeRange} from './CodeRange';
+import {isCodeRange, isPointInCodeRange} from './CodeRange';
 
 export type CodeSelection = CodeRange[];
 export type PossibleCodeSelection = CodeRange | CodeRange[];

--- a/packages/2d/src/lib/code/CodeSignal.ts
+++ b/packages/2d/src/lib/code/CodeSignal.ts
@@ -1,28 +1,23 @@
+import type {
+  Signal,
+  SignalValue,
+  ThreadGenerator,
+  TimingFunction,
+} from '@revideo/core';
 import {
   createSignal,
   deepLerp,
   DependencyContext,
-  Signal,
   SignalContext,
-  SignalValue,
-  ThreadGenerator,
-  TimingFunction,
   unwrap,
 } from '@revideo/core';
-import {Code} from '../components';
 import {addInitializer, getPropertyMetaOrCreate} from '../decorators';
 import {defaultDiffer} from './CodeDiffer';
 import {insert, replace} from './CodeFragment';
-import {CodeHighlighter} from './CodeHighlighter';
-import {CodePoint, CodeRange} from './CodeRange';
-import {
-  CODE,
-  CodeScope,
-  CodeTag,
-  parseCodeScope,
-  PossibleCodeScope,
-  resolveCodeTag,
-} from './CodeScope';
+import type {CodeHighlighter} from './CodeHighlighter';
+import type {CodePoint, CodeRange} from './CodeRange';
+import type {CodeScope, CodeTag, PossibleCodeScope} from './CodeScope';
+import {CODE, parseCodeScope, resolveCodeTag} from './CodeScope';
 import {defaultTokenize} from './CodeTokenizer';
 import {extractRange} from './extractRange';
 
@@ -81,9 +76,6 @@ export class CodeSignalContext<TOwner>
     private readonly highlighter?: SignalValue<CodeHighlighter | null>,
   ) {
     super(initial, deepLerp, owner);
-    if (owner instanceof Code) {
-      this.highlighter ??= owner.highlighter;
-    }
     Object.defineProperty(this.invokable, 'edit', {
       value: this.edit.bind(this),
     });

--- a/packages/2d/src/lib/code/LezerHighlighter.ts
+++ b/packages/2d/src/lib/code/LezerHighlighter.ts
@@ -1,7 +1,7 @@
-import {HighlightStyle} from '@codemirror/language';
-import {Parser, SyntaxNode, Tree} from '@lezer/common';
+import type {HighlightStyle} from '@codemirror/language';
+import type {Parser, SyntaxNode, Tree} from '@lezer/common';
 import {highlightTree} from '@lezer/highlight';
-import {CodeHighlighter, HighlightResult} from './CodeHighlighter';
+import type {CodeHighlighter, HighlightResult} from './CodeHighlighter';
 import {DefaultHighlightStyle} from './DefaultHighlightStyle';
 
 interface LezerCache {

--- a/packages/2d/src/lib/code/extractRange.ts
+++ b/packages/2d/src/lib/code/extractRange.ts
@@ -1,5 +1,6 @@
-import {CodeRange} from './CodeRange';
-import {CodeTag, resolveCodeTag} from './CodeScope';
+import type {CodeRange} from './CodeRange';
+import type {CodeTag} from './CodeScope';
+import {resolveCodeTag} from './CodeScope';
 
 /**
  * Transform the fragments to isolate the given range into its own fragment.

--- a/packages/2d/src/lib/components/Audio.ts
+++ b/packages/2d/src/lib/components/Audio.ts
@@ -1,6 +1,7 @@
 import {DependencyContext, PlaybackState} from '@revideo/core';
 import {computed, nodeName} from '../decorators';
-import {Media, MediaProps} from './Media';
+import type {MediaProps} from './Media';
+import {Media} from './Media';
 
 @nodeName('Audio')
 export class Audio extends Media {

--- a/packages/2d/src/lib/components/Bezier.ts
+++ b/packages/2d/src/lib/components/Bezier.ts
@@ -1,8 +1,9 @@
-import {BBox, SerializedVector2, Vector2} from '@revideo/core';
-import {CurveProfile} from '../curves';
-import {PolynomialSegment} from '../curves/PolynomialSegment';
+import type {SerializedVector2, Vector2} from '@revideo/core';
+import {BBox} from '@revideo/core';
+import type {CurveProfile} from '../curves';
+import type {PolynomialSegment} from '../curves/PolynomialSegment';
 import {computed} from '../decorators';
-import {DesiredLength} from '../partials';
+import type {DesiredLength} from '../partials';
 import {arc, drawLine, drawPivot, moveTo} from '../utils';
 import {Curve} from './Curve';
 

--- a/packages/2d/src/lib/components/Circle.ts
+++ b/packages/2d/src/lib/components/Circle.ts
@@ -1,14 +1,11 @@
-import {
-  BBox,
-  DEG2RAD,
-  SerializedVector2,
-  SignalValue,
-  SimpleSignal,
-} from '@revideo/core';
-import {CurveProfile, getCircleProfile} from '../curves';
+import type {SerializedVector2, SignalValue, SimpleSignal} from '@revideo/core';
+import {BBox, DEG2RAD} from '@revideo/core';
+import type {CurveProfile} from '../curves';
+import {getCircleProfile} from '../curves';
 import {computed, initial, nodeName, signal} from '../decorators';
-import {DesiredLength} from '../partials';
-import {Curve, CurveProps} from './Curve';
+import type {DesiredLength} from '../partials';
+import type {CurveProps} from './Curve';
+import {Curve} from './Curve';
 
 export interface CircleProps extends CurveProps {
   /**

--- a/packages/2d/src/lib/components/Code.ts
+++ b/packages/2d/src/lib/components/Code.ts
@@ -1,40 +1,45 @@
-import {
-  BBox,
-  createSignal,
-  experimentalLog,
-  map,
+import type {
   SerializedVector2,
   Signal,
   SignalValue,
   SimpleSignal,
   ThreadGenerator,
   TimingFunction,
-  unwrap,
-  useLogger,
-  useScene,
   Vector2,
 } from '@revideo/core';
 import {
-  CodeCursor,
+  BBox,
+  createSignal,
+  experimentalLog,
+  map,
+  unwrap,
+  useLogger,
+  useScene,
+} from '@revideo/core';
+import type {
   CodeFragmentDrawingInfo,
   CodeHighlighter,
   CodePoint,
   CodeRange,
   CodeSelection,
   CodeSignal,
+  PossibleCodeScope,
+  PossibleCodeSelection,
+} from '../code';
+import {
+  CodeCursor,
   codeSignal,
   CodeSignalContext,
   findAllCodeRanges,
   isPointInCodeSelection,
   lines,
   parseCodeSelection,
-  PossibleCodeScope,
-  PossibleCodeSelection,
   resolveScope,
 } from '../code';
 import {computed, initial, nodeName, parser, signal} from '../decorators';
-import {DesiredLength} from '../partials';
-import {Shape, ShapeProps} from './Shape';
+import type {DesiredLength} from '../partials';
+import type {ShapeProps} from './Shape';
+import {Shape} from './Shape';
 
 export interface DrawTokenHook {
   (

--- a/packages/2d/src/lib/components/CodeBlock.ts
+++ b/packages/2d/src/lib/components/CodeBlock.ts
@@ -1,10 +1,12 @@
-import {
+import type {
   SerializedVector2,
   Signal,
   SignalValue,
   SimpleSignal,
   ThreadGenerator,
   TimingFunction,
+} from '@revideo/core';
+import {
   Vector2,
   clampRemap,
   createComputedAsync,
@@ -17,19 +19,12 @@ import {
   useLogger,
   waitFor,
 } from '@revideo/core';
-import {
-  Code,
-  CodeStyle,
-  CodeTree,
-  MorphToken,
-  Token,
-  diff,
-  parse,
-  ready,
-} from 'code-fns';
+import type {Code, CodeStyle, CodeTree, MorphToken, Token} from 'code-fns';
+import {diff, parse, ready} from 'code-fns';
 import {computed, initial, nodeName, parser, signal} from '../decorators';
-import {DesiredLength} from '../partials';
-import {Shape, ShapeProps} from './Shape';
+import type {DesiredLength} from '../partials';
+import type {ShapeProps} from './Shape';
+import {Shape} from './Shape';
 
 type CodePoint = [number, number];
 type CodeRange = [CodePoint, CodePoint];

--- a/packages/2d/src/lib/components/CubicBezier.ts
+++ b/packages/2d/src/lib/components/CubicBezier.ts
@@ -1,10 +1,11 @@
-import {PossibleVector2, SignalValue, Vector2Signal} from '@revideo/core';
+import type {PossibleVector2, SignalValue, Vector2Signal} from '@revideo/core';
 import {CubicBezierSegment} from '../curves';
-import {PolynomialSegment} from '../curves/PolynomialSegment';
+import type {PolynomialSegment} from '../curves/PolynomialSegment';
 import {computed, vector2Signal} from '../decorators';
 import {bezierCurveTo, lineTo, moveTo} from '../utils';
-import {Bezier, BezierOverlayInfo} from './Bezier';
-import {CurveProps} from './Curve';
+import type {BezierOverlayInfo} from './Bezier';
+import {Bezier} from './Bezier';
+import type {CurveProps} from './Curve';
 
 export interface CubicBezierProps extends CurveProps {
   p0?: SignalValue<PossibleVector2>;

--- a/packages/2d/src/lib/components/Curve.ts
+++ b/packages/2d/src/lib/components/Curve.ts
@@ -1,19 +1,19 @@
-import {
+import type {
   BBox,
   SerializedVector2,
   SignalValue,
   SimpleSignal,
-  Vector2,
-  clamp,
 } from '@revideo/core';
-import {CurveDrawingInfo} from '../curves/CurveDrawingInfo';
-import {CurvePoint} from '../curves/CurvePoint';
-import {CurveProfile} from '../curves/CurveProfile';
+import {Vector2, clamp} from '@revideo/core';
+import type {CurveDrawingInfo} from '../curves/CurveDrawingInfo';
+import type {CurvePoint} from '../curves/CurvePoint';
+import type {CurveProfile} from '../curves/CurveProfile';
 import {getPointAtDistance} from '../curves/getPointAtDistance';
 import {computed, initial, nodeName, signal} from '../decorators';
-import {DesiredLength} from '../partials';
+import type {DesiredLength} from '../partials';
 import {lineTo, moveTo, resolveCanvasStyle} from '../utils';
-import {Shape, ShapeProps} from './Shape';
+import type {ShapeProps} from './Shape';
+import {Shape} from './Shape';
 
 export interface CurveProps extends ShapeProps {
   /**

--- a/packages/2d/src/lib/components/Grid.ts
+++ b/packages/2d/src/lib/components/Grid.ts
@@ -1,12 +1,13 @@
-import {
+import type {
   PossibleVector2,
   SignalValue,
   SimpleSignal,
   Vector2Signal,
-  map,
 } from '@revideo/core';
+import {map} from '@revideo/core';
 import {initial, nodeName, signal, vector2Signal} from '../decorators';
-import {Shape, ShapeProps} from './Shape';
+import type {ShapeProps} from './Shape';
+import {Shape} from './Shape';
 
 export interface GridProps extends ShapeProps {
   /**

--- a/packages/2d/src/lib/components/Icon.ts
+++ b/packages/2d/src/lib/components/Icon.ts
@@ -1,12 +1,13 @@
-import {
+import type {
   ColorSignal,
   PossibleColor,
   SignalValue,
   SimpleSignal,
-  useLogger,
 } from '@revideo/core';
+import {useLogger} from '@revideo/core';
 import {colorSignal, computed, initial, signal} from '../decorators';
-import {Img, ImgProps} from './Img';
+import type {ImgProps} from './Img';
+import {Img} from './Img';
 
 export interface IconProps extends ImgProps {
   /**

--- a/packages/2d/src/lib/components/Img.ts
+++ b/packages/2d/src/lib/components/Img.ts
@@ -1,19 +1,22 @@
+import type {
+  PossibleVector2,
+  SerializedVector2,
+  SignalValue,
+  SimpleSignal,
+} from '@revideo/core';
 import {
   BBox,
   Color,
   DependencyContext,
   DetailedError,
-  PossibleVector2,
-  SerializedVector2,
-  SignalValue,
-  SimpleSignal,
   Vector2,
   useLogger,
 } from '@revideo/core';
 import {computed, initial, nodeName, signal} from '../decorators';
-import {DesiredLength} from '../partials';
+import type {DesiredLength} from '../partials';
 import {drawImage} from '../utils';
-import {Rect, RectProps} from './Rect';
+import type {RectProps} from './Rect';
+import {Rect} from './Rect';
 
 const imageWithoutSource = `
 The image won't be visible unless you specify a source:

--- a/packages/2d/src/lib/components/Knot.ts
+++ b/packages/2d/src/lib/components/Knot.ts
@@ -1,11 +1,11 @@
-import {
+import type {
   PossibleVector2,
   Signal,
   SignalValue,
-  Vector2,
   Vector2Signal,
 } from '@revideo/core';
-import {KnotInfo} from '../curves';
+import {Vector2} from '@revideo/core';
+import type {KnotInfo} from '../curves';
 import {
   cloneable,
   compound,
@@ -15,7 +15,8 @@ import {
   signal,
   wrapper,
 } from '../decorators';
-import {Node, NodeProps} from './Node';
+import type {NodeProps} from './Node';
+import {Node} from './Node';
 
 export interface KnotProps extends NodeProps {
   /**

--- a/packages/2d/src/lib/components/Latex.ts
+++ b/packages/2d/src/lib/components/Latex.ts
@@ -1,18 +1,15 @@
-import {
-  DependencyContext,
-  SignalValue,
-  SimpleSignal,
-  useLogger,
-} from '@revideo/core';
+import type {SignalValue, SimpleSignal} from '@revideo/core';
+import {DependencyContext, useLogger} from '@revideo/core';
 import {liteAdaptor} from 'mathjax-full/js/adaptors/liteAdaptor';
 import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html';
 import {TeX} from 'mathjax-full/js/input/tex';
 import {AllPackages} from 'mathjax-full/js/input/tex/AllPackages';
 import {mathjax} from 'mathjax-full/js/mathjax';
 import {SVG} from 'mathjax-full/js/output/svg';
-import {OptionList} from 'mathjax-full/js/util/Options';
+import type {OptionList} from 'mathjax-full/js/util/Options';
 import {initial, signal} from '../decorators';
-import {Img, ImgProps} from './Img';
+import type {ImgProps} from './Img';
+import {Img} from './Img';
 
 const Adaptor = liteAdaptor();
 RegisterHTMLHandler(Adaptor);

--- a/packages/2d/src/lib/components/Layout.ts
+++ b/packages/2d/src/lib/components/Layout.ts
@@ -1,8 +1,5 @@
-import {
-  BBox,
-  DependencyContext,
+import type {
   InterpolationFunction,
-  Origin,
   PossibleSpacing,
   PossibleVector2,
   SerializedVector2,
@@ -13,16 +10,21 @@ import {
   SpacingSignal,
   ThreadGenerator,
   TimingFunction,
-  Vector2,
   Vector2Signal,
+} from '@revideo/core';
+import {
+  BBox,
+  DependencyContext,
+  Origin,
+  Vector2,
   boolLerp,
   modify,
   originToOffset,
   threadable,
   tween,
 } from '@revideo/core';
+import type {Vector2LengthSignal} from '../decorators';
 import {
-  Vector2LengthSignal,
   addInitializer,
   cloneable,
   computed,
@@ -35,7 +37,7 @@ import {
   vector2Signal,
 } from '../decorators';
 import {spacingSignal} from '../decorators/spacingSignal';
-import {
+import type {
   DesiredLength,
   FlexBasis,
   FlexContent,
@@ -48,7 +50,8 @@ import {
   TextWrap,
 } from '../partials';
 import {drawLine, drawPivot, is} from '../utils';
-import {Node, NodeProps} from './Node';
+import type {NodeProps} from './Node';
+import {Node} from './Node';
 
 export interface LayoutProps extends NodeProps {
   layout?: LayoutMode;

--- a/packages/2d/src/lib/components/Line.ts
+++ b/packages/2d/src/lib/components/Line.ts
@@ -1,18 +1,21 @@
-import {
-  BBox,
-  createSignal,
+import type {
   PossibleVector2,
   SignalValue,
   SimpleSignal,
-  threadable,
   ThreadGenerator,
   TimingFunction,
+} from '@revideo/core';
+import {
+  BBox,
+  createSignal,
+  threadable,
   tween,
   unwrap,
   useLogger,
   Vector2,
 } from '@revideo/core';
-import {CurveProfile, getPolylineProfile} from '../curves';
+import type {CurveProfile} from '../curves';
+import {getPolylineProfile} from '../curves';
 import {
   calculateLerpDistance,
   polygonLength,
@@ -20,7 +23,8 @@ import {
 } from '../curves/createCurveProfileLerp';
 import {computed, initial, nodeName, signal} from '../decorators';
 import {arc, drawLine, drawPivot, lineTo, moveTo} from '../utils';
-import {Curve, CurveProps} from './Curve';
+import type {CurveProps} from './Curve';
+import {Curve} from './Curve';
 import {Layout} from './Layout';
 
 const lineWithoutPoints = `

--- a/packages/2d/src/lib/components/Media.ts
+++ b/packages/2d/src/lib/components/Media.ts
@@ -1,15 +1,15 @@
+import type {SignalValue, SimpleSignal} from '@revideo/core';
 import {
   DependencyContext,
   PlaybackState,
-  SignalValue,
-  SimpleSignal,
   clamp,
   isReactive,
   useLogger,
   useThread,
 } from '@revideo/core';
 import {computed, initial, nodeName, signal} from '../decorators';
-import {Rect, RectProps} from './Rect';
+import type {RectProps} from './Rect';
+import {Rect} from './Rect';
 
 export interface MediaProps extends RectProps {
   src?: SignalValue<string>;

--- a/packages/2d/src/lib/components/Node.ts
+++ b/packages/2d/src/lib/components/Node.ts
@@ -1,7 +1,5 @@
-import {
-  BBox,
+import type {
   ColorSignal,
-  DependencyContext,
   PossibleColor,
   PossibleSpacing,
   PossibleVector2,
@@ -14,11 +12,15 @@ import {
   SpacingSignal,
   ThreadGenerator,
   TimingFunction,
+  Vector2Signal,
+} from '@revideo/core';
+import {
+  BBox,
+  DependencyContext,
   UNIFORM_DESTINATION_MATRIX,
   UNIFORM_SOURCE_MATRIX,
   UNIFORM_TIME,
   Vector2,
-  Vector2Signal,
   all,
   clamp,
   createSignal,
@@ -46,14 +48,15 @@ import {
   vector2Signal,
   wrapper,
 } from '../decorators';
-import {FiltersSignal, filtersSignal} from '../decorators/filtersSignal';
+import type {FiltersSignal} from '../decorators/filtersSignal';
+import {filtersSignal} from '../decorators/filtersSignal';
 import {spacingSignal} from '../decorators/spacingSignal';
-import {Filter} from '../partials';
-import {
+import type {Filter} from '../partials';
+import type {
   PossibleShaderConfig,
   ShaderConfig,
-  parseShader,
 } from '../partials/ShaderConfig';
+import {parseShader} from '../partials/ShaderConfig';
 import {useScene2D} from '../scenes/useScene2D';
 import {drawLine} from '../utils';
 import type {View2D} from './View2D';

--- a/packages/2d/src/lib/components/Path.ts
+++ b/packages/2d/src/lib/components/Path.ts
@@ -1,20 +1,17 @@
-import {
-  BBox,
-  createSignal,
-  isReactive,
+import type {
   SignalValue,
   SimpleSignal,
-  threadable,
   TimingFunction,
-  tween,
   Vector2,
 } from '@revideo/core';
-import {CurveProfile} from '../curves';
+import {BBox, createSignal, isReactive, threadable, tween} from '@revideo/core';
+import type {CurveProfile} from '../curves';
 import {createCurveProfileLerp} from '../curves/createCurveProfileLerp';
 import {getPathProfile} from '../curves/getPathProfile';
 import {computed, signal} from '../decorators';
 import {drawLine, drawPivot} from '../utils';
-import {Curve, CurveProps} from './Curve';
+import type {CurveProps} from './Curve';
+import {Curve} from './Curve';
 
 export interface PathProps extends CurveProps {
   data: SignalValue<string>;

--- a/packages/2d/src/lib/components/Polygon.ts
+++ b/packages/2d/src/lib/components/Polygon.ts
@@ -1,15 +1,12 @@
-import {
-  BBox,
-  SerializedVector2,
-  SignalValue,
-  SimpleSignal,
-  Vector2,
-} from '@revideo/core';
-import {CurveProfile, getPolylineProfile} from '../curves';
+import type {SerializedVector2, SignalValue, SimpleSignal} from '@revideo/core';
+import {BBox, Vector2} from '@revideo/core';
+import type {CurveProfile} from '../curves';
+import {getPolylineProfile} from '../curves';
 import {computed, initial, signal} from '../decorators';
-import {DesiredLength} from '../partials';
+import type {DesiredLength} from '../partials';
 import {drawPolygon} from '../utils';
-import {Curve, CurveProps} from './Curve';
+import type {CurveProps} from './Curve';
+import {Curve} from './Curve';
 
 export interface PolygonProps extends CurveProps {
   /**

--- a/packages/2d/src/lib/components/QuadBezier.ts
+++ b/packages/2d/src/lib/components/QuadBezier.ts
@@ -1,10 +1,11 @@
-import {PossibleVector2, SignalValue, Vector2Signal} from '@revideo/core';
+import type {PossibleVector2, SignalValue, Vector2Signal} from '@revideo/core';
 import {QuadBezierSegment} from '../curves';
-import {PolynomialSegment} from '../curves/PolynomialSegment';
+import type {PolynomialSegment} from '../curves/PolynomialSegment';
 import {computed, vector2Signal} from '../decorators';
 import {lineTo, moveTo, quadraticCurveTo} from '../utils';
-import {Bezier, BezierOverlayInfo} from './Bezier';
-import {CurveProps} from './Curve';
+import type {BezierOverlayInfo} from './Bezier';
+import {Bezier} from './Bezier';
+import type {CurveProps} from './Curve';
 
 export interface QuadBezierProps extends CurveProps {
   p0?: SignalValue<PossibleVector2>;

--- a/packages/2d/src/lib/components/Ray.ts
+++ b/packages/2d/src/lib/components/Ray.ts
@@ -1,8 +1,11 @@
-import {BBox, PossibleVector2, SignalValue, Vector2Signal} from '@revideo/core';
-import {CurveProfile, LineSegment} from '../curves';
+import type {PossibleVector2, SignalValue, Vector2Signal} from '@revideo/core';
+import {BBox} from '@revideo/core';
+import type {CurveProfile} from '../curves';
+import {LineSegment} from '../curves';
 import {nodeName, vector2Signal} from '../decorators';
 import {arc, drawLine, drawPivot} from '../utils';
-import {Curve, CurveProps} from './Curve';
+import type {CurveProps} from './Curve';
+import {Curve} from './Curve';
 
 export interface RayProps extends CurveProps {
   /**

--- a/packages/2d/src/lib/components/Rect.ts
+++ b/packages/2d/src/lib/components/Rect.ts
@@ -1,17 +1,18 @@
-import {
-  BBox,
+import type {
   PossibleSpacing,
   SerializedVector2,
   SignalValue,
   SimpleSignal,
   SpacingSignal,
 } from '@revideo/core';
+import {BBox} from '@revideo/core';
 import {getRectProfile} from '../curves/getRectProfile';
 import {computed, initial, nodeName, signal} from '../decorators';
 import {spacingSignal} from '../decorators/spacingSignal';
-import {DesiredLength} from '../partials';
+import type {DesiredLength} from '../partials';
 import {drawRoundRect} from '../utils';
-import {Curve, CurveProps} from './Curve';
+import type {CurveProps} from './Curve';
+import {Curve} from './Curve';
 
 export interface RectProps extends CurveProps {
   /**

--- a/packages/2d/src/lib/components/Rive.ts
+++ b/packages/2d/src/lib/components/Rive.ts
@@ -1,13 +1,16 @@
-import {BBox, SignalValue, SimpleSignal, useThread} from '@revideo/core';
-import RiveInitializer, {
+import type {SignalValue, SimpleSignal} from '@revideo/core';
+import {BBox, useThread} from '@revideo/core';
+import type {
   Artboard,
   File,
   LinearAnimationInstance,
   Renderer,
   RiveCanvas,
 } from '@rive-app/canvas-advanced';
+import RiveInitializer from '@rive-app/canvas-advanced';
 import {computed, initial, nodeName, signal} from '../decorators';
-import {Rect, RectProps} from './Rect';
+import type {RectProps} from './Rect';
+import {Rect} from './Rect';
 
 export interface RiveProps extends RectProps {
   src?: SignalValue<string>;

--- a/packages/2d/src/lib/components/SVG.ts
+++ b/packages/2d/src/lib/components/SVG.ts
@@ -1,12 +1,14 @@
-import {
-  BBox,
-  Matrix2D,
+import type {
   PossibleSpacing,
   SerializedVector2,
   SignalValue,
   SimpleSignal,
   ThreadGenerator,
   TimingFunction,
+} from '@revideo/core';
+import {
+  BBox,
+  Matrix2D,
   Vector2,
   all,
   clampRemap,
@@ -19,16 +21,23 @@ import {
   useLogger,
 } from '@revideo/core';
 import {computed, signal} from '../decorators';
-import {DesiredLength, PossibleCanvasStyle} from '../partials';
+import type {DesiredLength, PossibleCanvasStyle} from '../partials';
 import {applyTransformDiff, getTransformDiff} from '../utils/diff';
-import {Circle, CircleProps} from './Circle';
-import {Img, ImgProps} from './Img';
+import type {CircleProps} from './Circle';
+import {Circle} from './Circle';
+import type {ImgProps} from './Img';
+import {Img} from './Img';
 import {Layout} from './Layout';
-import {Line, LineProps} from './Line';
-import {Node, NodeProps} from './Node';
-import {Path, PathProps} from './Path';
-import {Rect, RectProps} from './Rect';
-import {Shape, ShapeProps} from './Shape';
+import type {LineProps} from './Line';
+import {Line} from './Line';
+import type {NodeProps} from './Node';
+import {Node} from './Node';
+import type {PathProps} from './Path';
+import {Path} from './Path';
+import type {RectProps} from './Rect';
+import {Rect} from './Rect';
+import type {ShapeProps} from './Shape';
+import {Shape} from './Shape';
 import {View2D} from './View2D';
 
 /**

--- a/packages/2d/src/lib/components/Shape.ts
+++ b/packages/2d/src/lib/components/Shape.ts
@@ -1,7 +1,5 @@
+import type {BBox, SignalValue, SimpleSignal} from '@revideo/core';
 import {
-  BBox,
-  SignalValue,
-  SimpleSignal,
   createSignal,
   easeOutExpo,
   linear,
@@ -9,13 +7,12 @@ import {
   threadable,
 } from '@revideo/core';
 import {computed, initial, nodeName, signal} from '../decorators';
-import {
-  CanvasStyleSignal,
-  canvasStyleSignal,
-} from '../decorators/canvasStyleSignal';
-import {PossibleCanvasStyle} from '../partials';
+import type {CanvasStyleSignal} from '../decorators/canvasStyleSignal';
+import {canvasStyleSignal} from '../decorators/canvasStyleSignal';
+import type {PossibleCanvasStyle} from '../partials';
 import {resolveCanvasStyle} from '../utils';
-import {Layout, LayoutProps} from './Layout';
+import type {LayoutProps} from './Layout';
+import {Layout} from './Layout';
 
 export interface ShapeProps extends LayoutProps {
   fill?: SignalValue<PossibleCanvasStyle>;

--- a/packages/2d/src/lib/components/Spline.ts
+++ b/packages/2d/src/lib/components/Spline.ts
@@ -1,22 +1,15 @@
-import {
-  BBox,
+import type {
   PossibleVector2,
   SerializedVector2,
   SignalValue,
   SimpleSignal,
-  Vector2,
-  unwrap,
-  useLogger,
 } from '@revideo/core';
-import {
-  CubicBezierSegment,
-  CurveProfile,
-  KnotInfo,
-  getBezierSplineProfile,
-} from '../curves';
-import {PolynomialSegment} from '../curves/PolynomialSegment';
+import {BBox, Vector2, unwrap, useLogger} from '@revideo/core';
+import type {CurveProfile, KnotInfo} from '../curves';
+import {CubicBezierSegment, getBezierSplineProfile} from '../curves';
+import type {PolynomialSegment} from '../curves/PolynomialSegment';
 import {computed, initial, signal} from '../decorators';
-import {DesiredLength} from '../partials';
+import type {DesiredLength} from '../partials';
 import {
   arc,
   bezierCurveTo,
@@ -26,9 +19,10 @@ import {
   moveTo,
   quadraticCurveTo,
 } from '../utils';
-import {Curve, CurveProps} from './Curve';
+import type {CurveProps} from './Curve';
+import {Curve} from './Curve';
 import {Knot} from './Knot';
-import {Node} from './Node';
+import type {Node} from './Node';
 
 const splineWithInsufficientKnots = `
 The spline won't be visible unless you specify at least two knots:

--- a/packages/2d/src/lib/components/Txt.ts
+++ b/packages/2d/src/lib/components/Txt.ts
@@ -1,20 +1,18 @@
-import {
-  DEFAULT,
+import type {
   InterpolationFunction,
   SignalValue,
   SimpleSignal,
   ThreadGenerator,
   TimingFunction,
-  all,
-  capitalize,
-  threadable,
 } from '@revideo/core';
+import {DEFAULT, all, capitalize, threadable} from '@revideo/core';
 import {computed, initial, nodeName, signal} from '../decorators';
 import {is} from '../utils';
-import {Node} from './Node';
-import {Shape, ShapeProps} from './Shape';
+import type {Node} from './Node';
+import type {ShapeProps} from './Shape';
+import {Shape} from './Shape';
 import {TxtLeaf} from './TxtLeaf';
-import {ComponentChildren} from './types';
+import type {ComponentChildren} from './types';
 
 type TxtChildren = string | Node | (string | Node)[];
 type AnyTxt = Txt | TxtLeaf;

--- a/packages/2d/src/lib/components/TxtLeaf.ts
+++ b/packages/2d/src/lib/components/TxtLeaf.ts
@@ -1,11 +1,5 @@
-import {
-  BBox,
-  SignalValue,
-  SimpleSignal,
-  capitalize,
-  lazy,
-  textLerp,
-} from '@revideo/core';
+import type {SignalValue, SimpleSignal} from '@revideo/core';
+import {BBox, capitalize, lazy, textLerp} from '@revideo/core';
 import {
   computed,
   initial,
@@ -13,7 +7,8 @@ import {
   nodeName,
   signal,
 } from '../decorators';
-import {Shape, ShapeProps} from './Shape';
+import type {ShapeProps} from './Shape';
+import {Shape} from './Shape';
 import {Txt} from './Txt';
 
 export interface TxtLeafProps extends ShapeProps {

--- a/packages/2d/src/lib/components/Video.ts
+++ b/packages/2d/src/lib/components/Video.ts
@@ -1,18 +1,13 @@
-import {
-  BBox,
-  DependencyContext,
-  PlaybackState,
-  SerializedVector2,
-  SignalValue,
-  SimpleSignal,
-} from '@revideo/core';
+import type {SerializedVector2, SignalValue, SimpleSignal} from '@revideo/core';
+import {BBox, DependencyContext, PlaybackState} from '@revideo/core';
 import Hls from 'hls.js';
 import {computed, initial, nodeName, signal} from '../decorators';
-import {DesiredLength} from '../partials';
+import type {DesiredLength} from '../partials';
 import {drawImage} from '../utils';
 import {ImageCommunication} from '../utils/video/ffmpeg-client';
 import {dropExtractor, getFrame} from '../utils/video/mp4-parser-manager';
-import {Media, MediaProps} from './Media';
+import type {MediaProps} from './Media';
+import {Media} from './Media';
 
 export interface VideoProps extends MediaProps {
   /**

--- a/packages/2d/src/lib/components/View2D.ts
+++ b/packages/2d/src/lib/components/View2D.ts
@@ -1,9 +1,11 @@
-import {PlaybackState, SimpleSignal, lazy} from '@revideo/core';
+import type {SimpleSignal} from '@revideo/core';
+import {PlaybackState, lazy} from '@revideo/core';
 import {initial, signal} from '../decorators';
 import {nodeName} from '../decorators/nodeName';
 import {useScene2D} from '../scenes/useScene2D';
 import type {Node} from './Node';
-import {Rect, RectProps} from './Rect';
+import type {RectProps} from './Rect';
+import {Rect} from './Rect';
 
 export interface View2DProps extends RectProps {
   assetHash: string;

--- a/packages/2d/src/lib/components/__tests__/generatorTest.ts
+++ b/packages/2d/src/lib/components/__tests__/generatorTest.ts
@@ -1,6 +1,7 @@
-import {ThreadGeneratorFactory, threads} from '@revideo/core';
+import type {ThreadGeneratorFactory} from '@revideo/core';
+import {threads} from '@revideo/core';
 import {useScene2D} from '../../scenes';
-import {View2D} from '../View2D';
+import type {View2D} from '../View2D';
 
 /**
  * Turn a generator factory into a test function.

--- a/packages/2d/src/lib/components/__tests__/mockScene2D.ts
+++ b/packages/2d/src/lib/components/__tests__/mockScene2D.ts
@@ -1,8 +1,7 @@
+import type {FullSceneDescription, ThreadGeneratorFactory} from '@revideo/core';
 import {
-  FullSceneDescription,
   PlaybackManager,
   PlaybackStatus,
-  ThreadGeneratorFactory,
   Vector2,
   endPlayback,
   endScene,
@@ -11,7 +10,7 @@ import {
 } from '@revideo/core';
 import {afterAll, beforeAll, beforeEach} from 'vitest';
 import {Scene2D, makeScene2D} from '../../scenes';
-import {View2D} from '../View2D';
+import type {View2D} from '../View2D';
 
 /**
  * Set up the test environment to support creating nodes.

--- a/packages/2d/src/lib/curves/ArcSegment.ts
+++ b/packages/2d/src/lib/curves/ArcSegment.ts
@@ -1,6 +1,6 @@
 import {BBox, DEG2RAD, Matrix2D, Vector2, lazy} from '@revideo/core';
 import {View2D} from '../components/View2D';
-import {CurvePoint} from './CurvePoint';
+import type {CurvePoint} from './CurvePoint';
 import {Segment} from './Segment';
 
 export class ArcSegment extends Segment {

--- a/packages/2d/src/lib/curves/CircleSegment.ts
+++ b/packages/2d/src/lib/curves/CircleSegment.ts
@@ -1,5 +1,5 @@
 import {Vector2, clamp} from '@revideo/core';
-import {CurvePoint} from './CurvePoint';
+import type {CurvePoint} from './CurvePoint';
 import {Segment} from './Segment';
 
 export class CircleSegment extends Segment {

--- a/packages/2d/src/lib/curves/CurveDrawingInfo.ts
+++ b/packages/2d/src/lib/curves/CurveDrawingInfo.ts
@@ -1,4 +1,4 @@
-import {Vector2} from '@revideo/core';
+import type {Vector2} from '@revideo/core';
 
 export interface CurveDrawingInfo {
   path: Path2D;

--- a/packages/2d/src/lib/curves/CurveProfile.ts
+++ b/packages/2d/src/lib/curves/CurveProfile.ts
@@ -1,4 +1,4 @@
-import {Segment} from './Segment';
+import type {Segment} from './Segment';
 
 export interface CurveProfile {
   arcLength: number;

--- a/packages/2d/src/lib/curves/KnotInfo.ts
+++ b/packages/2d/src/lib/curves/KnotInfo.ts
@@ -1,4 +1,4 @@
-import {Vector2} from '@revideo/core';
+import type {Vector2} from '@revideo/core';
 
 export type KnotAutoHandles = {start: number; end: number};
 

--- a/packages/2d/src/lib/curves/LineSegment.ts
+++ b/packages/2d/src/lib/curves/LineSegment.ts
@@ -1,6 +1,6 @@
-import {Vector2} from '@revideo/core';
+import type {Vector2} from '@revideo/core';
 import {lineTo, moveTo} from '../utils';
-import {CurvePoint} from './CurvePoint';
+import type {CurvePoint} from './CurvePoint';
 import {Segment} from './Segment';
 
 export class LineSegment extends Segment {

--- a/packages/2d/src/lib/curves/PolynomialSegment.ts
+++ b/packages/2d/src/lib/curves/PolynomialSegment.ts
@@ -1,7 +1,7 @@
-import {BBox, Vector2} from '@revideo/core';
+import type {BBox, Vector2} from '@revideo/core';
 import {moveTo} from '../utils';
-import {CurvePoint} from './CurvePoint';
-import {Polynomial2D} from './Polynomial2D';
+import type {CurvePoint} from './CurvePoint';
+import type {Polynomial2D} from './Polynomial2D';
 import {Segment} from './Segment';
 import {UniformPolynomialCurveSampler} from './UniformPolynomialCurveSampler';
 

--- a/packages/2d/src/lib/curves/Segment.ts
+++ b/packages/2d/src/lib/curves/Segment.ts
@@ -1,5 +1,5 @@
-import {Vector2} from '@revideo/core';
-import {CurvePoint} from './CurvePoint';
+import type {Vector2} from '@revideo/core';
+import type {CurvePoint} from './CurvePoint';
 
 export abstract class Segment {
   public abstract readonly points: Vector2[];

--- a/packages/2d/src/lib/curves/UniformPolynomialCurveSampler.ts
+++ b/packages/2d/src/lib/curves/UniformPolynomialCurveSampler.ts
@@ -1,6 +1,7 @@
-import {Vector2, clamp, remap} from '@revideo/core';
-import {CurvePoint} from './CurvePoint';
-import {PolynomialSegment} from './PolynomialSegment';
+import type {Vector2} from '@revideo/core';
+import {clamp, remap} from '@revideo/core';
+import type {CurvePoint} from './CurvePoint';
+import type {PolynomialSegment} from './PolynomialSegment';
 
 /**
  * Class to uniformly sample points on a given polynomial curve.

--- a/packages/2d/src/lib/curves/createCurveProfileLerp.ts
+++ b/packages/2d/src/lib/curves/createCurveProfileLerp.ts
@@ -1,5 +1,5 @@
 import {Vector2} from '@revideo/core';
-import {CurveProfile} from './CurveProfile';
+import type {CurveProfile} from './CurveProfile';
 import {LineSegment} from './LineSegment';
 import {getPointAtDistance} from './getPointAtDistance';
 import {getPolylineProfile} from './getPolylineProfile';

--- a/packages/2d/src/lib/curves/getBezierSplineProfile.ts
+++ b/packages/2d/src/lib/curves/getBezierSplineProfile.ts
@@ -1,8 +1,8 @@
 import {Vector2, clamp} from '@revideo/core';
 import {CubicBezierSegment} from './CubicBezierSegment';
-import {CurveProfile} from './CurveProfile';
-import {KnotInfo} from './KnotInfo';
-import {PolynomialSegment} from './PolynomialSegment';
+import type {CurveProfile} from './CurveProfile';
+import type {KnotInfo} from './KnotInfo';
+import type {PolynomialSegment} from './PolynomialSegment';
 import {QuadBezierSegment} from './QuadBezierSegment';
 
 function isCubicSegment(

--- a/packages/2d/src/lib/curves/getCircleProfile.ts
+++ b/packages/2d/src/lib/curves/getCircleProfile.ts
@@ -1,8 +1,8 @@
 import {Vector2} from '@revideo/core';
 import {ArcSegment} from './ArcSegment';
-import {CurveProfile} from './CurveProfile';
+import type {CurveProfile} from './CurveProfile';
 import {LineSegment} from './LineSegment';
-import {Segment} from './Segment';
+import type {Segment} from './Segment';
 
 export function getCircleProfile(
   size: Vector2,

--- a/packages/2d/src/lib/curves/getPathProfile.ts
+++ b/packages/2d/src/lib/curves/getPathProfile.ts
@@ -1,11 +1,12 @@
 import {Vector2, clamp} from '@revideo/core';
-import parse, {PathCommand} from 'parse-svg-path';
+import type {PathCommand} from 'parse-svg-path';
+import parse from 'parse-svg-path';
 import {ArcSegment} from './ArcSegment';
 import {CubicBezierSegment} from './CubicBezierSegment';
-import {CurveProfile} from './CurveProfile';
+import type {CurveProfile} from './CurveProfile';
 import {LineSegment} from './LineSegment';
 import {QuadBezierSegment} from './QuadBezierSegment';
-import {Segment} from './Segment';
+import type {Segment} from './Segment';
 
 function addSegmentToProfile(profile: CurveProfile, segment: Segment) {
   profile.segments.push(segment);

--- a/packages/2d/src/lib/curves/getPointAtDistance.ts
+++ b/packages/2d/src/lib/curves/getPointAtDistance.ts
@@ -1,6 +1,6 @@
 import {Vector2, clamp} from '@revideo/core';
-import {CurvePoint} from './CurvePoint';
-import {CurveProfile} from './CurveProfile';
+import type {CurvePoint} from './CurvePoint';
+import type {CurveProfile} from './CurveProfile';
 
 export function getPointAtDistance(
   profile: CurveProfile,

--- a/packages/2d/src/lib/curves/getPolylineProfile.ts
+++ b/packages/2d/src/lib/curves/getPolylineProfile.ts
@@ -1,6 +1,7 @@
-import {Vector2, clamp} from '@revideo/core';
+import type {Vector2} from '@revideo/core';
+import {clamp} from '@revideo/core';
 import {CircleSegment} from './CircleSegment';
-import {CurveProfile} from './CurveProfile';
+import type {CurveProfile} from './CurveProfile';
 import {LineSegment} from './LineSegment';
 
 export function getPolylineProfile(

--- a/packages/2d/src/lib/curves/getRectProfile.ts
+++ b/packages/2d/src/lib/curves/getRectProfile.ts
@@ -1,10 +1,11 @@
-import {BBox, Spacing, Vector2} from '@revideo/core';
+import type {BBox, Spacing} from '@revideo/core';
+import {Vector2} from '@revideo/core';
 import {adjustRectRadius} from '../utils';
 import {CircleSegment} from './CircleSegment';
 import {CubicBezierSegment} from './CubicBezierSegment';
-import {CurveProfile} from './CurveProfile';
+import type {CurveProfile} from './CurveProfile';
 import {LineSegment} from './LineSegment';
-import {Segment} from './Segment';
+import type {Segment} from './Segment';
 
 export function getRectProfile(
   rect: BBox,

--- a/packages/2d/src/lib/decorators/canvasStyleSignal.ts
+++ b/packages/2d/src/lib/decorators/canvasStyleSignal.ts
@@ -1,4 +1,5 @@
-import {Color, Signal} from '@revideo/core';
+import type {Signal} from '@revideo/core';
+import {Color} from '@revideo/core';
 import type {CanvasStyle, PossibleCanvasStyle} from '../partials';
 import {canvasStyleParser} from '../utils';
 import {initial, interpolation, parser, signal} from './signal';

--- a/packages/2d/src/lib/decorators/defaultStyle.ts
+++ b/packages/2d/src/lib/decorators/defaultStyle.ts
@@ -1,5 +1,5 @@
 import {capitalize} from '@revideo/core';
-import {Layout} from '../components';
+import type {Layout} from '../components';
 
 export function defaultStyle<T>(
   styleName: string,

--- a/packages/2d/src/lib/decorators/filtersSignal.ts
+++ b/packages/2d/src/lib/decorators/filtersSignal.ts
@@ -1,16 +1,19 @@
-import {
+import type {
   Signal,
-  SignalContext,
   SignalValue,
   SimpleSignal,
   ThreadGenerator,
   TimingFunction,
+} from '@revideo/core';
+import {
+  SignalContext,
   all,
   deepLerp,
   easeInOutCubic,
   unwrap,
 } from '@revideo/core';
-import {FILTERS, Filter, FilterName} from '../partials';
+import type {FilterName} from '../partials';
+import {FILTERS, Filter} from '../partials';
 import {addInitializer} from './initializers';
 import {getPropertyMetaOrCreate} from './signal';
 

--- a/packages/2d/src/lib/decorators/signal.test.ts
+++ b/packages/2d/src/lib/decorators/signal.test.ts
@@ -1,4 +1,5 @@
-import {DEFAULT, SimpleSignal} from '@revideo/core';
+import type {SimpleSignal} from '@revideo/core';
+import {DEFAULT} from '@revideo/core';
 import {beforeEach, describe, expect, test, vi} from 'vitest';
 import {initial, initializeSignals, parser, signal} from './signal';
 

--- a/packages/2d/src/lib/decorators/signal.ts
+++ b/packages/2d/src/lib/decorators/signal.ts
@@ -1,12 +1,9 @@
-import {
-  capitalize,
-  deepLerp,
+import type {
   InterpolationFunction,
-  SignalContext,
   SignalValue,
   TimingFunction,
-  useLogger,
 } from '@revideo/core';
+import {capitalize, deepLerp, SignalContext, useLogger} from '@revideo/core';
 import {makeSignalExtensions} from '../utils/makeSignalExtensions';
 import {addInitializer, initialize} from './initializers';
 

--- a/packages/2d/src/lib/decorators/vector2Signal.ts
+++ b/packages/2d/src/lib/decorators/vector2Signal.ts
@@ -1,4 +1,5 @@
-import {PossibleVector2, Signal, Vector2} from '@revideo/core';
+import type {PossibleVector2, Signal} from '@revideo/core';
+import {Vector2} from '@revideo/core';
 import type {Length} from '../partials';
 import {compound} from './compound';
 import {wrapper} from './signal';

--- a/packages/2d/src/lib/partials/Filter.ts
+++ b/packages/2d/src/lib/partials/Filter.ts
@@ -1,10 +1,5 @@
-import {
-  createSignal,
-  map,
-  SignalValue,
-  SimpleSignal,
-  transformScalar,
-} from '@revideo/core';
+import type {SignalValue, SimpleSignal} from '@revideo/core';
+import {createSignal, map, transformScalar} from '@revideo/core';
 
 /**
  * All possible CSS filter names.

--- a/packages/2d/src/lib/partials/Gradient.ts
+++ b/packages/2d/src/lib/partials/Gradient.ts
@@ -1,12 +1,11 @@
-import {
-  Color,
+import type {
   PossibleColor,
   PossibleVector2,
   SignalValue,
   SimpleSignal,
   Vector2Signal,
-  unwrap,
 } from '@revideo/core';
+import {Color, unwrap} from '@revideo/core';
 import {computed} from '../decorators/computed';
 import {initial, initializeSignals, signal} from '../decorators/signal';
 import {vector2Signal} from '../decorators/vector2Signal';

--- a/packages/2d/src/lib/partials/Pattern.ts
+++ b/packages/2d/src/lib/partials/Pattern.ts
@@ -1,4 +1,4 @@
-import {SimpleSignal} from '@revideo/core';
+import type {SimpleSignal} from '@revideo/core';
 import {computed} from '../decorators/computed';
 import {initial, initializeSignals, signal} from '../decorators/signal';
 

--- a/packages/2d/src/lib/partials/ShaderConfig.ts
+++ b/packages/2d/src/lib/partials/ShaderConfig.ts
@@ -1,11 +1,6 @@
-import {
-  experimentalLog,
-  SignalValue,
-  useLogger,
-  useScene,
-  WebGLConvertible,
-} from '@revideo/core';
-import {Node} from '../components';
+import type {SignalValue, WebGLConvertible} from '@revideo/core';
+import {experimentalLog, useLogger, useScene} from '@revideo/core';
+import type {Node} from '../components';
 
 /**
  * Describes a shader program used to apply effects to nodes.

--- a/packages/2d/src/lib/partials/types.ts
+++ b/packages/2d/src/lib/partials/types.ts
@@ -1,4 +1,4 @@
-import {Color, PossibleColor} from '@revideo/core';
+import type {Color, PossibleColor} from '@revideo/core';
 import type {Gradient} from './Gradient';
 import type {Pattern} from './Pattern';
 

--- a/packages/2d/src/lib/scenes/Scene2D.ts
+++ b/packages/2d/src/lib/scenes/Scene2D.ts
@@ -1,17 +1,20 @@
-import {
+import type {
   AssetInfo,
   FullSceneDescription,
-  GeneratorScene,
   Inspectable,
   InspectedAttributes,
   InspectedElement,
   Scene,
-  SceneRenderEvent,
   ThreadGeneratorFactory,
+} from '@revideo/core';
+import {
+  GeneratorScene,
+  SceneRenderEvent,
   Vector2,
   useLogger,
 } from '@revideo/core';
-import {Audio, Media, Node, Video, View2D} from '../components';
+import type {Node} from '../components';
+import {Audio, Media, Video, View2D} from '../components';
 
 export class Scene2D extends GeneratorScene<View2D> implements Inspectable {
   private view: View2D | null = null;

--- a/packages/2d/src/lib/utils/CanvasUtils.ts
+++ b/packages/2d/src/lib/utils/CanvasUtils.ts
@@ -1,5 +1,7 @@
-import {BBox, Color, Spacing, Vector2} from '@revideo/core';
-import {CanvasStyle, Gradient, Pattern, PossibleCanvasStyle} from '../partials';
+import type {BBox, Spacing} from '@revideo/core';
+import {Color, Vector2} from '@revideo/core';
+import type {CanvasStyle, PossibleCanvasStyle} from '../partials';
+import {Gradient, Pattern} from '../partials';
 
 export function canvasStyleParser(style: PossibleCanvasStyle) {
   if (style === null) {

--- a/packages/2d/src/lib/utils/makeSignalExtensions.ts
+++ b/packages/2d/src/lib/utils/makeSignalExtensions.ts
@@ -1,5 +1,6 @@
-import {SignalExtensions, capitalize} from '@revideo/core';
-import {PropertyMetadata} from '../decorators';
+import type {SignalExtensions} from '@revideo/core';
+import {capitalize} from '@revideo/core';
+import type {PropertyMetadata} from '../decorators';
 
 export function makeSignalExtensions<TSetterValue, TValue extends TSetterValue>(
   meta: Partial<PropertyMetadata<TValue>> = {},

--- a/packages/2d/src/lib/utils/video/parser/parser.ts
+++ b/packages/2d/src/lib/utils/video/parser/parser.ts
@@ -2,7 +2,8 @@ import {createFile} from 'mp4box';
 import {FrameSampler} from './sampler';
 import {Segment} from './segment';
 import {MP4FileSink} from './sink';
-import {Edit, description, mp4BoxEditToEdit} from './utils';
+import type {Edit} from './utils';
+import {description, mp4BoxEditToEdit} from './utils';
 
 /**
  * Loads the file at the given URI until it finds the moov box.

--- a/packages/2d/src/lib/utils/video/parser/sampler.ts
+++ b/packages/2d/src/lib/utils/video/parser/sampler.ts
@@ -1,4 +1,4 @@
-import {Segment} from './segment';
+import type {Segment} from './segment';
 
 export class FrameSampler {
   private framesRequested = 0;

--- a/packages/2d/src/lib/utils/video/parser/segment.ts
+++ b/packages/2d/src/lib/utils/video/parser/segment.ts
@@ -1,5 +1,5 @@
 import {MP4FileSink} from './sink';
-import {Edit} from './utils';
+import type {Edit} from './utils';
 
 const MAX_DECODE_QUEUE_SIZE = 30;
 

--- a/packages/cli/src/server/download.ts
+++ b/packages/cli/src/server/download.ts
@@ -1,4 +1,4 @@
-import {Request, Response} from 'express';
+import type {Request, Response} from 'express';
 import {promises as fs} from 'fs';
 import path from 'path';
 

--- a/packages/cli/src/server/render.ts
+++ b/packages/cli/src/server/render.ts
@@ -1,6 +1,6 @@
 import {renderVideo} from '@revideo/renderer';
 import axios from 'axios';
-import {Request, Response} from 'express';
+import type {Request, Response} from 'express';
 import path from 'path';
 import {v4 as uuidv4} from 'uuid';
 import {scheduleCleanup} from '../utils';

--- a/packages/core/src/app/PlaybackStatus.ts
+++ b/packages/core/src/app/PlaybackStatus.ts
@@ -1,4 +1,4 @@
-import {PlaybackManager, PlaybackState} from './PlaybackManager';
+import type {PlaybackManager, PlaybackState} from './PlaybackManager';
 
 /**
  * A read-only representation of the playback.

--- a/packages/core/src/app/Player.ts
+++ b/packages/core/src/app/Player.ts
@@ -3,14 +3,14 @@ import {
   EventDispatcher,
   ValueDispatcher,
 } from '../events';
-import {Scene} from '../scenes';
+import type {Scene} from '../scenes';
 import {clamp} from '../tweening';
 import {Vector2} from '../types';
 import {Semaphore} from '../utils';
-import {Logger} from './Logger';
+import type {Logger} from './Logger';
 import {PlaybackManager, PlaybackState} from './PlaybackManager';
 import {PlaybackStatus} from './PlaybackStatus';
-import {Project} from './Project';
+import type {Project} from './Project';
 import {SharedWebGLContext} from './SharedWebGLContext';
 
 export interface PlayerState extends Record<string, unknown> {

--- a/packages/core/src/app/Project.ts
+++ b/packages/core/src/app/Project.ts
@@ -1,8 +1,8 @@
-import {FfmpegExporterOptions, ImageExporterOptions} from '../exporter';
+import type {FfmpegExporterOptions, ImageExporterOptions} from '../exporter';
 import type {Plugin} from '../plugin';
-import {SceneDescription} from '../scenes';
-import {CanvasColorSpace, Color, Vector2} from '../types';
-import {Logger} from './Logger';
+import type {SceneDescription} from '../scenes';
+import type {CanvasColorSpace, Color, Vector2} from '../types';
+import type {Logger} from './Logger';
 
 // TODO(refactor): check if we can get rid of this
 export interface Versions {

--- a/packages/core/src/app/Renderer.ts
+++ b/packages/core/src/app/Renderer.ts
@@ -1,6 +1,6 @@
 import {EventDispatcher, ValueDispatcher} from '../events';
+import type {ExporterClass} from '../exporter';
 import {
-  ExporterClass,
   FFmpegExporterClient,
   ImageExporter,
   WasmExporter,
@@ -14,7 +14,8 @@ import {PlaybackManager, PlaybackState} from './PlaybackManager';
 import {PlaybackStatus} from './PlaybackStatus';
 import type {ExporterSettings, Project} from './Project';
 import {SharedWebGLContext} from './SharedWebGLContext';
-import {Stage, StageSettings} from './Stage';
+import type {StageSettings} from './Stage';
+import {Stage} from './Stage';
 import {TimeEstimator} from './TimeEstimator';
 
 export interface RendererSettings extends StageSettings {

--- a/packages/core/src/app/SharedWebGLContext.ts
+++ b/packages/core/src/app/SharedWebGLContext.ts
@@ -1,4 +1,4 @@
-import {Logger} from './Logger';
+import type {Logger} from './Logger';
 
 const SOURCE_URL_REGEX = /^\/\/# sourceURL=(.*)$/gm;
 const INFO_LOG_REGEX = /ERROR: \d+:(\d+): (.*)/g;

--- a/packages/core/src/app/Stage.ts
+++ b/packages/core/src/app/Stage.ts
@@ -1,7 +1,7 @@
-import {Scene} from '../scenes';
+import type {Scene} from '../scenes';
 import {unwrap} from '../signals';
-import type {Color} from '../types';
-import {CanvasColorSpace, Vector2} from '../types';
+import type {CanvasColorSpace, Color} from '../types';
+import {Vector2} from '../types';
 import {getContext} from '../utils';
 
 export interface StageSettings {

--- a/packages/core/src/app/makeProject.ts
+++ b/packages/core/src/app/makeProject.ts
@@ -1,12 +1,8 @@
 import DefaultPlugin from '../plugin/DefaultPlugin';
 import {Color, Vector2} from '../types';
 import {Logger} from './Logger';
-import {
-  Project,
-  UserProject,
-  UserProjectSettings,
-  createVersionObject,
-} from './Project';
+import type {Project, UserProject, UserProjectSettings} from './Project';
+import {createVersionObject} from './Project';
 
 export const defaultUserProjectSettings: UserProjectSettings = {
   shared: {

--- a/packages/core/src/events/AsyncEventDispatcher.ts
+++ b/packages/core/src/events/AsyncEventDispatcher.ts
@@ -1,4 +1,5 @@
-import {EventDispatcherBase, Subscribable} from './EventDispatcherBase';
+import type {Subscribable} from './EventDispatcherBase';
+import {EventDispatcherBase} from './EventDispatcherBase';
 
 export interface AsyncEventHandler<T> {
   (value: T): Promise<void>;

--- a/packages/core/src/events/EventDispatcher.ts
+++ b/packages/core/src/events/EventDispatcher.ts
@@ -1,4 +1,5 @@
-import {EventDispatcherBase, Subscribable} from './EventDispatcherBase';
+import type {Subscribable} from './EventDispatcherBase';
+import {EventDispatcherBase} from './EventDispatcherBase';
 
 /**
  * Dispatches a {@link SubscribableEvent}.

--- a/packages/core/src/events/FlagDispatcher.ts
+++ b/packages/core/src/events/FlagDispatcher.ts
@@ -1,8 +1,5 @@
-import {
-  EventDispatcherBase,
-  EventHandler,
-  Subscribable,
-} from './EventDispatcherBase';
+import type {EventHandler, Subscribable} from './EventDispatcherBase';
+import {EventDispatcherBase} from './EventDispatcherBase';
 
 /**
  * Dispatches a {@link SubscribableFlagEvent}.

--- a/packages/core/src/events/ValueDispatcher.ts
+++ b/packages/core/src/events/ValueDispatcher.ts
@@ -1,8 +1,5 @@
-import {
-  EventDispatcherBase,
-  EventHandler,
-  Subscribable,
-} from './EventDispatcherBase';
+import type {EventHandler} from './EventDispatcherBase';
+import {EventDispatcherBase, Subscribable} from './EventDispatcherBase';
 
 /**
  * Dispatches a {@link SubscribableValueEvent}

--- a/packages/core/src/exporter/FFmpegExporter.ts
+++ b/packages/core/src/exporter/FFmpegExporter.ts
@@ -1,11 +1,11 @@
-import {Project} from '../app/Project';
+import type {Project} from '../app/Project';
 import type {
   AssetInfo,
   RendererResult,
   RendererSettings,
 } from '../app/Renderer';
 import {EventDispatcher} from '../events';
-import {Exporter} from './Exporter';
+import type {Exporter} from './Exporter';
 import {download} from './download-videos';
 
 type ServerResponse =

--- a/packages/core/src/exporter/ImageExporter.ts
+++ b/packages/core/src/exporter/ImageExporter.ts
@@ -3,7 +3,7 @@ import type {Project} from '../app/Project';
 import type {AssetInfo, RendererSettings} from '../app/Renderer';
 import {EventDispatcher} from '../events';
 import {clamp} from '../tweening';
-import {CanvasOutputMimeType} from '../types';
+import type {CanvasOutputMimeType} from '../types';
 import type {Exporter} from './Exporter';
 import {download} from './download-videos';
 

--- a/packages/core/src/exporter/WasmExporter.ts
+++ b/packages/core/src/exporter/WasmExporter.ts
@@ -1,7 +1,7 @@
 import loadMp4Module from 'mp4-wasm';
-import {Project} from '../app/Project';
+import type {Project} from '../app/Project';
 import type {AssetInfo, RendererSettings} from '../app/Renderer';
-import {Exporter} from './Exporter';
+import type {Exporter} from './Exporter';
 import {download} from './download-videos';
 
 export class WasmExporter implements Exporter {

--- a/packages/core/src/exporter/download-videos.ts
+++ b/packages/core/src/exporter/download-videos.ts
@@ -1,4 +1,4 @@
-import {AssetInfo} from '../app';
+import type {AssetInfo} from '../app';
 
 export async function download(assets: AssetInfo[][]): Promise<void> {
   const videoRanges: Map<string, {start: number; end: number}> = new Map();

--- a/packages/core/src/flow/all.ts
+++ b/packages/core/src/flow/all.ts
@@ -1,5 +1,6 @@
 import {decorate, threadable} from '../decorators';
-import {ThreadGenerator, join} from '../threading';
+import type {ThreadGenerator} from '../threading';
+import {join} from '../threading';
 
 decorate(all, threadable());
 /**

--- a/packages/core/src/flow/any.ts
+++ b/packages/core/src/flow/any.ts
@@ -1,5 +1,6 @@
 import {decorate, threadable} from '../decorators';
-import {ThreadGenerator, join} from '../threading';
+import type {ThreadGenerator} from '../threading';
+import {join} from '../threading';
 
 decorate(any, threadable());
 /**

--- a/packages/core/src/flow/chain.ts
+++ b/packages/core/src/flow/chain.ts
@@ -1,5 +1,6 @@
 import {decorate, threadable} from '../decorators';
-import {ThreadGenerator, isThreadGenerator} from '../threading';
+import type {ThreadGenerator} from '../threading';
+import {isThreadGenerator} from '../threading';
 
 decorate(chain, threadable());
 /**

--- a/packages/core/src/flow/delay.ts
+++ b/packages/core/src/flow/delay.ts
@@ -1,5 +1,6 @@
 import {decorate, threadable} from '../decorators';
-import {ThreadGenerator, isThreadGenerator} from '../threading';
+import type {ThreadGenerator} from '../threading';
+import {isThreadGenerator} from '../threading';
 import {waitFor} from './scheduling';
 
 decorate(delay, threadable());

--- a/packages/core/src/flow/every.ts
+++ b/packages/core/src/flow/every.ts
@@ -1,5 +1,5 @@
 import {decorate, threadable} from '../decorators';
-import {ThreadGenerator} from '../threading';
+import type {ThreadGenerator} from '../threading';
 import {usePlayback} from '../utils';
 
 export interface EveryCallback {

--- a/packages/core/src/flow/loop.ts
+++ b/packages/core/src/flow/loop.ts
@@ -1,5 +1,5 @@
 import {decorate, threadable} from '../decorators';
-import {ThreadGenerator} from '../threading';
+import type {ThreadGenerator} from '../threading';
 import {useLogger, useThread} from '../utils';
 
 const infiniteLoop = `

--- a/packages/core/src/flow/loopFor.ts
+++ b/packages/core/src/flow/loopFor.ts
@@ -1,7 +1,7 @@
 import {decorate, threadable} from '../decorators';
-import {ThreadGenerator} from '../threading';
+import type {ThreadGenerator} from '../threading';
 import {usePlayback, useThread} from '../utils';
-import {LoopCallback} from './loop';
+import type {LoopCallback} from './loop';
 
 decorate(loopFor, threadable());
 /**

--- a/packages/core/src/flow/noop.ts
+++ b/packages/core/src/flow/noop.ts
@@ -1,5 +1,5 @@
 import {decorate, threadable} from '../decorators';
-import {ThreadGenerator} from '../threading';
+import type {ThreadGenerator} from '../threading';
 
 decorate(noop, threadable());
 /**

--- a/packages/core/src/flow/run.ts
+++ b/packages/core/src/flow/run.ts
@@ -1,4 +1,5 @@
-import {setTaskName, ThreadGenerator} from '../threading';
+import type {ThreadGenerator} from '../threading';
+import {setTaskName} from '../threading';
 /**
  * Turn the given generator function into a task.
  *

--- a/packages/core/src/flow/scheduling.ts
+++ b/packages/core/src/flow/scheduling.ts
@@ -1,5 +1,5 @@
 import {decorate, threadable} from '../decorators';
-import {ThreadGenerator} from '../threading';
+import type {ThreadGenerator} from '../threading';
 import {usePlayback, useThread} from '../utils';
 
 decorate(waitFor, threadable());

--- a/packages/core/src/flow/sequence.ts
+++ b/packages/core/src/flow/sequence.ts
@@ -1,5 +1,6 @@
 import {decorate, threadable} from '../decorators';
-import {ThreadGenerator, join} from '../threading';
+import type {ThreadGenerator} from '../threading';
+import {join} from '../threading';
 import {waitFor} from './scheduling';
 
 decorate(sequence, threadable());

--- a/packages/core/src/scenes/GeneratorScene.ts
+++ b/packages/core/src/scenes/GeneratorScene.ts
@@ -1,18 +1,14 @@
-import {AssetInfo, Logger, PlaybackStatus} from '../app';
+import type {AssetInfo, Logger, PlaybackStatus} from '../app';
 import {decorate, threadable} from '../decorators';
 import {EventDispatcher, ValueDispatcher} from '../events';
-import {DependencyContext, SignalValue} from '../signals';
-import {
-  Thread,
-  ThreadGenerator,
-  isPromisable,
-  isPromise,
-  threads,
-} from '../threading';
-import {Vector2} from '../types';
+import type {SignalValue} from '../signals';
+import {DependencyContext} from '../signals';
+import type {Thread, ThreadGenerator} from '../threading';
+import {isPromisable, isPromise, threads} from '../threading';
+import type {Vector2} from '../types';
 import {endPlayback, endScene, startPlayback, startScene} from '../utils';
 import {LifecycleEvents} from './LifecycleEvents';
-import {
+import type {
   CachedSceneData,
   FullSceneDescription,
   Scene,
@@ -22,7 +18,7 @@ import {
 import {SceneState} from './SceneState';
 import {Shaders} from './Shaders';
 import {Slides} from './Slides';
-import {Threadable} from './Threadable';
+import type {Threadable} from './Threadable';
 import {Variables} from './Variables';
 
 export interface ThreadGeneratorFactory<T> {

--- a/packages/core/src/scenes/Inspectable.ts
+++ b/packages/core/src/scenes/Inspectable.ts
@@ -1,4 +1,4 @@
-import {Vector2} from '../types/Vector';
+import type {Vector2} from '../types/Vector';
 
 /**
  * Represents an element to inspect.

--- a/packages/core/src/scenes/LifecycleEvents.ts
+++ b/packages/core/src/scenes/LifecycleEvents.ts
@@ -1,5 +1,6 @@
 import {EventDispatcher} from '../events';
-import {Scene, SceneRenderEvent} from './Scene';
+import type {Scene} from './Scene';
+import {SceneRenderEvent} from './Scene';
 
 /**
  * Lifecycle events for {@link Scene} that are cleared on every reset.

--- a/packages/core/src/scenes/Shaders.ts
+++ b/packages/core/src/scenes/Shaders.ts
@@ -1,5 +1,8 @@
-import {SharedWebGLContext, WebGLContextOwner} from '../app/SharedWebGLContext';
-import {Scene} from './Scene';
+import type {
+  SharedWebGLContext,
+  WebGLContextOwner,
+} from '../app/SharedWebGLContext';
+import type {Scene} from './Scene';
 
 /**
  * @internal

--- a/packages/core/src/scenes/Threadable.ts
+++ b/packages/core/src/scenes/Threadable.ts
@@ -1,5 +1,5 @@
-import {SubscribableValueEvent} from '../events';
-import {Thread} from '../threading';
+import type {SubscribableValueEvent} from '../events';
+import type {Thread} from '../threading';
 
 /**
  * Scenes can implement this interface to display their thread hierarchy in the

--- a/packages/core/src/scenes/Variables.ts
+++ b/packages/core/src/scenes/Variables.ts
@@ -1,4 +1,5 @@
-import {createSignal, SimpleSignal} from '../signals';
+import type {SimpleSignal} from '../signals';
+import {createSignal} from '../signals';
 import type {Scene} from './Scene';
 
 export class Variables {

--- a/packages/core/src/signals/CompoundSignalContext.ts
+++ b/packages/core/src/signals/CompoundSignalContext.ts
@@ -1,6 +1,8 @@
-import {InterpolationFunction, map} from '../tweening';
-import {Signal, SignalContext} from './SignalContext';
-import {SignalExtensions, SignalValue} from './types';
+import type {InterpolationFunction} from '../tweening';
+import {map} from '../tweening/helpers';
+import type {Signal} from './SignalContext';
+import {SignalContext} from './SignalContext';
+import type {SignalExtensions, SignalValue} from './types';
 import {isReactive, modify} from './utils';
 
 export type CompoundSignal<

--- a/packages/core/src/signals/DependencyContext.ts
+++ b/packages/core/src/signals/DependencyContext.ts
@@ -1,5 +1,6 @@
-import {FlagDispatcher, Subscribable} from '../events';
-import {Promisable} from '../threading';
+import type {Subscribable} from '../events';
+import {FlagDispatcher} from '../events';
+import type {Promisable} from '../threading';
 import {DetailedError} from '../utils';
 
 export interface PromiseHandle<T> {

--- a/packages/core/src/signals/SignalContext.ts
+++ b/packages/core/src/signals/SignalContext.ts
@@ -1,11 +1,11 @@
 import {run, waitFor} from '../flow';
-import {ThreadGenerator} from '../threading';
+import type {ThreadGenerator} from '../threading';
 import type {InterpolationFunction, TimingFunction} from '../tweening';
 import {easeInOutCubic, tween} from '../tweening';
 import {errorToLog, useLogger} from '../utils';
 import {DependencyContext} from './DependencyContext';
 import {DEFAULT} from './symbols';
-import {
+import type {
   SignalExtensions,
   SignalGenerator,
   SignalGetter,

--- a/packages/core/src/signals/createComputed.ts
+++ b/packages/core/src/signals/createComputed.ts
@@ -1,4 +1,5 @@
-import {Computed, ComputedContext} from '../signals';
+import type {Computed} from '../signals';
+import {ComputedContext} from '../signals';
 
 export function createComputed<TValue>(
   factory: (...args: any[]) => TValue,

--- a/packages/core/src/signals/createComputedAsync.ts
+++ b/packages/core/src/signals/createComputedAsync.ts
@@ -1,9 +1,5 @@
-import {
-  Computed,
-  ComputedContext,
-  createSignal,
-  PromiseHandle,
-} from '../signals';
+import type {Computed, PromiseHandle} from '../signals';
+import {ComputedContext, createSignal} from '../signals';
 import {createComputed} from './createComputed';
 
 export function createComputedAsync<T>(

--- a/packages/core/src/signals/createSignal.ts
+++ b/packages/core/src/signals/createSignal.ts
@@ -1,5 +1,7 @@
-import {SignalContext, SignalValue, SimpleSignal} from '../signals';
-import {InterpolationFunction, deepLerp} from '../tweening';
+import type {SignalValue, SimpleSignal} from '../signals';
+import {SignalContext} from '../signals';
+import type {InterpolationFunction} from '../tweening';
+import {deepLerp} from '../tweening';
 
 export function createSignal<TValue, TOwner = void>(
   initial?: SignalValue<TValue>,

--- a/packages/core/src/signals/types.ts
+++ b/packages/core/src/signals/types.ts
@@ -1,6 +1,6 @@
 import type {ThreadGenerator} from '../threading';
 import type {InterpolationFunction, TimingFunction} from '../tweening';
-import {DEFAULT} from './symbols';
+import type {DEFAULT} from './symbols';
 
 export type SignalValue<TValue> = TValue | (() => TValue);
 export type SignalGenerator<

--- a/packages/core/src/signals/utils.ts
+++ b/packages/core/src/signals/utils.ts
@@ -1,4 +1,4 @@
-import {SignalValue} from './types';
+import type {SignalValue} from './types';
 
 export function isReactive<T>(value: SignalValue<T>): value is () => T {
   return typeof value === 'function';

--- a/packages/core/src/threading/Thread.ts
+++ b/packages/core/src/threading/Thread.ts
@@ -1,7 +1,8 @@
 import {noop} from '../flow';
 import {createSignal} from '../signals';
 import {endThread, startThread, useLogger} from '../utils';
-import {ThreadGenerator, isThreadGenerator} from './ThreadGenerator';
+import type {ThreadGenerator} from './ThreadGenerator';
+import {isThreadGenerator} from './ThreadGenerator';
 import {getTaskName, setTaskName} from './names';
 
 const reusedGenerator = `

--- a/packages/core/src/threading/ThreadGenerator.ts
+++ b/packages/core/src/threading/ThreadGenerator.ts
@@ -1,4 +1,4 @@
-import {Thread} from './Thread';
+import type {Thread} from './Thread';
 
 export interface Promisable<T> {
   toPromise(): Promise<T>;

--- a/packages/core/src/threading/cancel.ts
+++ b/packages/core/src/threading/cancel.ts
@@ -1,5 +1,5 @@
 import {useThread} from '../utils';
-import {ThreadGenerator} from './ThreadGenerator';
+import type {ThreadGenerator} from './ThreadGenerator';
 
 /**
  * Cancel all listed tasks.

--- a/packages/core/src/threading/join.ts
+++ b/packages/core/src/threading/join.ts
@@ -1,7 +1,7 @@
 import {decorate, threadable} from '../decorators';
 import {useThread} from '../utils';
-import {Thread} from './Thread';
-import {ThreadGenerator} from './ThreadGenerator';
+import type {Thread} from './Thread';
+import type {ThreadGenerator} from './ThreadGenerator';
 
 decorate(join, threadable());
 /**

--- a/packages/core/src/threading/spawn.ts
+++ b/packages/core/src/threading/spawn.ts
@@ -1,5 +1,5 @@
 import {useThread} from '../utils';
-import {ThreadGenerator} from './ThreadGenerator';
+import type {ThreadGenerator} from './ThreadGenerator';
 
 /**
  * Run the given task concurrently.

--- a/packages/core/src/threading/threads.ts
+++ b/packages/core/src/threading/threads.ts
@@ -1,7 +1,8 @@
 import {decorate, threadable} from '../decorators';
 import {usePlayback} from '../utils';
 import {Thread} from './Thread';
-import {ThreadGenerator, isThreadGenerator} from './ThreadGenerator';
+import type {ThreadGenerator} from './ThreadGenerator';
+import {isThreadGenerator} from './ThreadGenerator';
 import {setTaskName} from './names';
 
 /**

--- a/packages/core/src/transitions/fadeTransition.ts
+++ b/packages/core/src/transitions/fadeTransition.ts
@@ -1,5 +1,5 @@
 import {createSignal} from '../signals';
-import {ThreadGenerator} from '../threading';
+import type {ThreadGenerator} from '../threading';
 import {useTransition} from './useTransition';
 
 /**

--- a/packages/core/src/transitions/slideTransition.ts
+++ b/packages/core/src/transitions/slideTransition.ts
@@ -1,6 +1,7 @@
 import {all} from '../flow';
-import {ThreadGenerator} from '../threading';
-import {Direction, Origin, Vector2} from '../types';
+import type {ThreadGenerator} from '../threading';
+import type {Origin} from '../types';
+import {Direction, Vector2} from '../types';
 import {useScene} from '../utils';
 import {useTransition} from './useTransition';
 

--- a/packages/core/src/transitions/useTransition.ts
+++ b/packages/core/src/transitions/useTransition.ts
@@ -1,4 +1,4 @@
-import {SignalValue} from '../signals/types';
+import type {SignalValue} from '../signals/types';
 import {useScene} from '../utils';
 
 /**

--- a/packages/core/src/transitions/zoomInTransition.ts
+++ b/packages/core/src/transitions/zoomInTransition.ts
@@ -1,8 +1,9 @@
 import {all} from '../flow';
 import {createSignal} from '../signals';
-import {ThreadGenerator} from '../threading';
+import type {ThreadGenerator} from '../threading';
 import {clampRemap, easeInOutCubic, linear} from '../tweening';
-import {BBox, Vector2} from '../types';
+import type {BBox} from '../types';
+import {Vector2} from '../types';
 import {useScene} from '../utils';
 import {useTransition} from './useTransition';
 

--- a/packages/core/src/transitions/zoomOutTransition.ts
+++ b/packages/core/src/transitions/zoomOutTransition.ts
@@ -1,8 +1,9 @@
 import {all} from '../flow';
 import {createSignal} from '../signals';
-import {ThreadGenerator} from '../threading';
+import type {ThreadGenerator} from '../threading';
 import {clampRemap, easeInOutCubic, linear} from '../tweening';
-import {BBox, Vector2} from '../types';
+import type {BBox} from '../types';
+import {Vector2} from '../types';
 import {useScene} from '../utils';
 import {useTransition} from './useTransition';
 

--- a/packages/core/src/tweening/spring.ts
+++ b/packages/core/src/tweening/spring.ts
@@ -1,5 +1,5 @@
 import {decorate, threadable} from '../decorators';
-import {ThreadGenerator} from '../threading';
+import type {ThreadGenerator} from '../threading';
 import {useLogger, useThread} from '../utils';
 
 type ProgressFunction = (value: number, time: number) => void;

--- a/packages/core/src/types/BBox.ts
+++ b/packages/core/src/types/BBox.ts
@@ -1,8 +1,11 @@
-import {CompoundSignal, CompoundSignalContext, SignalValue} from '../signals';
-import {InterpolationFunction, arcLerp, map} from '../tweening';
-import {PossibleMatrix2D} from './Matrix2D';
-import {PossibleSpacing, Spacing} from './Spacing';
-import {Type, WebGLConvertible} from './Type';
+import type {CompoundSignal, SignalValue} from '../signals';
+import {CompoundSignalContext} from '../signals';
+import type {InterpolationFunction} from '../tweening';
+import {arcLerp, map} from '../tweening';
+import type {PossibleMatrix2D} from './Matrix2D';
+import type {PossibleSpacing} from './Spacing';
+import {Spacing} from './Spacing';
+import type {Type, WebGLConvertible} from './Type';
 import {Vector2} from './Vector';
 
 export type SerializedBBox = {

--- a/packages/core/src/types/Matrix2D.test.ts
+++ b/packages/core/src/types/Matrix2D.test.ts
@@ -1,6 +1,7 @@
 import {beforeEach, describe, expect, test} from 'vitest';
 import {Matrix2D} from './Matrix2D';
-import {PossibleVector2, Vector2} from './Vector';
+import type {PossibleVector2} from './Vector';
+import {Vector2} from './Vector';
 
 type Matrix2DValues = [number, number, number, number, number, number];
 

--- a/packages/core/src/types/Matrix2D.ts
+++ b/packages/core/src/types/Matrix2D.ts
@@ -1,6 +1,8 @@
 import {DEG2RAD} from '../utils';
-import {EPSILON, Type, WebGLConvertible} from './Type';
-import {PossibleVector2, Vector2} from './Vector';
+import type {Type, WebGLConvertible} from './Type';
+import {EPSILON} from './Type';
+import type {PossibleVector2} from './Vector';
+import {Vector2} from './Vector';
 
 export type PossibleMatrix2D =
   | Matrix2D

--- a/packages/core/src/types/Spacing.ts
+++ b/packages/core/src/types/Spacing.ts
@@ -1,6 +1,8 @@
-import {CompoundSignal, CompoundSignalContext, SignalValue} from '../signals';
-import {InterpolationFunction, map} from '../tweening';
-import {Type, WebGLConvertible} from './Type';
+import type {CompoundSignal, SignalValue} from '../signals';
+import {CompoundSignalContext} from '../signals';
+import type {InterpolationFunction} from '../tweening';
+import {map} from '../tweening';
+import type {Type, WebGLConvertible} from './Type';
 
 export type SerializedSpacing = {
   top: number;

--- a/packages/core/src/types/Vector.test.ts
+++ b/packages/core/src/types/Vector.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, test} from 'vitest';
 import {createSignal} from '../signals';
-import {PossibleVector2, Vector2} from '../types';
+import type {PossibleVector2} from '../types';
+import {Vector2} from '../types';
 
 describe('Vector2', () => {
   test('Correctly parses values', () => {

--- a/packages/core/src/types/Vector.ts
+++ b/packages/core/src/types/Vector.ts
@@ -1,14 +1,13 @@
-import {
-  CompoundSignal,
-  CompoundSignalContext,
-  Signal,
-  SignalValue,
-} from '../signals';
-import {InterpolationFunction, arcLerp, clamp, map} from '../tweening';
+import type {CompoundSignal, Signal, SignalValue} from '../signals';
+import {CompoundSignalContext} from '../signals';
+import type {InterpolationFunction} from '../tweening';
+import {arcLerp, clamp, map} from '../tweening';
 import {DEG2RAD, RAD2DEG} from '../utils';
-import {Matrix2D, PossibleMatrix2D} from './Matrix2D';
+import type {PossibleMatrix2D} from './Matrix2D';
+import {Matrix2D} from './Matrix2D';
 import {Direction, Origin} from './Origin';
-import {EPSILON, Type, WebGLConvertible} from './Type';
+import type {Type, WebGLConvertible} from './Type';
+import {EPSILON} from './Type';
 
 export type SerializedVector2<T = number> = {
   x: T;

--- a/packages/core/src/utils/createRefArray.ts
+++ b/packages/core/src/utils/createRefArray.ts
@@ -1,4 +1,4 @@
-import {Reference} from './createRef';
+import type {Reference} from './createRef';
 
 type ProxyTarget<T> = {
   (): void;

--- a/packages/core/src/utils/createRefMap.ts
+++ b/packages/core/src/utils/createRefMap.ts
@@ -1,4 +1,5 @@
-import {createRef, Reference} from './createRef';
+import type {Reference} from './createRef';
+import {createRef} from './createRef';
 
 export type ReferenceMap<T> = Map<string, Reference<T>> &
   Record<string, Reference<T>> & {

--- a/packages/core/src/utils/debug.test.ts
+++ b/packages/core/src/utils/debug.test.ts
@@ -1,6 +1,6 @@
 import {beforeEach, describe, expect, test, vi} from 'vitest';
 import {LogLevel, Logger} from '../app';
-import {Scene} from '../scenes';
+import type {Scene} from '../scenes';
 import {BBox, Vector2} from '../types';
 import {debug, startScene, useLogger} from '../utils';
 

--- a/packages/core/src/utils/debug.ts
+++ b/packages/core/src/utils/debug.ts
@@ -1,4 +1,4 @@
-import {LogPayload} from '../app';
+import type {LogPayload} from '../app';
 import {useLogger} from './useScene';
 
 function stringify(value: any): string {

--- a/packages/core/src/utils/experimentalLog.ts
+++ b/packages/core/src/utils/experimentalLog.ts
@@ -1,4 +1,5 @@
-import {LogLevel, LogPayload} from '../app';
+import type {LogPayload} from '../app/Logger';
+import {LogLevel} from '../app/Logger';
 import {experimentalFeatures} from './ExperimentalError';
 
 export function experimentalLog(message: string, remarks?: string): LogPayload {

--- a/packages/core/src/utils/usePlayback.ts
+++ b/packages/core/src/utils/usePlayback.ts
@@ -1,4 +1,4 @@
-import {PlaybackStatus} from '../app';
+import type {PlaybackStatus} from '../app';
 
 const PlaybackStack: PlaybackStatus[] = [];
 

--- a/packages/e2e/src/app.ts
+++ b/packages/e2e/src/app.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
-import puppeteer, {Page} from 'puppeteer';
+import type {Page} from 'puppeteer';
+import puppeteer from 'puppeteer';
 import {fileURLToPath} from 'url';
 import {createServer} from 'vite';
 

--- a/packages/e2e/src/rendering.test.ts
+++ b/packages/e2e/src/rendering.test.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs';
 import {toMatchImageSnapshot} from 'jest-image-snapshot';
 import {afterAll, beforeAll, describe, expect, test} from 'vitest';
-import {App, start} from './app';
+import type {App} from './app';
+import {start} from './app';
 
 expect.extend({toMatchImageSnapshot});
 

--- a/packages/examples/src/components/Switch.tsx
+++ b/packages/examples/src/components/Switch.tsx
@@ -1,18 +1,13 @@
-import {
-  Circle,
-  Node,
-  NodeProps,
-  Rect,
-  colorSignal,
-  initial,
-  signal,
-} from '@revideo/2d';
-import {
-  Color,
+import type {NodeProps} from '@revideo/2d';
+import {Circle, Node, Rect, colorSignal, initial, signal} from '@revideo/2d';
+import type {
   ColorSignal,
   PossibleColor,
   SignalValue,
   SimpleSignal,
+} from '@revideo/core';
+import {
+  Color,
   all,
   createRef,
   createSignal,

--- a/packages/ffmpeg/src/generate-audio.ts
+++ b/packages/ffmpeg/src/generate-audio.ts
@@ -1,12 +1,12 @@
-import {AssetInfo, FfmpegExporterOptions} from '@revideo/core';
+import type {AssetInfo, FfmpegExporterOptions} from '@revideo/core';
 import * as ffmpeg from 'fluent-ffmpeg';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {extensions} from './ffmpeg-exporter-server';
 import {ffmpegSettings} from './settings';
+import type {AudioCodec} from './utils';
 import {
-  AudioCodec,
   checkForAudioStream,
   getSampleRate,
   makeSureFolderExists,

--- a/packages/player-react/src/index.tsx
+++ b/packages/player-react/src/index.tsx
@@ -1,6 +1,7 @@
 'use client';
-import {Player as CorePlayer, Project} from '@revideo/core';
-import {ComponentProps, useCallback, useEffect, useRef, useState} from 'react';
+import type {Player as CorePlayer, Project} from '@revideo/core';
+import type {ComponentProps} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import {Controls} from './controls';
 import './index.css';
 import {shouldShowControls} from './utils';

--- a/packages/player-react/src/internal.ts
+++ b/packages/player-react/src/internal.ts
@@ -1,4 +1,5 @@
-import {Player, Project, Stage, getFullPreviewSettings} from '@revideo/core';
+import type {Project} from '@revideo/core';
+import {Player, Stage, getFullPreviewSettings} from '@revideo/core';
 
 import {Vector2} from '@revideo/core';
 

--- a/packages/renderer/client/render.ts
+++ b/packages/renderer/client/render.ts
@@ -1,7 +1,6 @@
+import type {Project, RenderVideoUserProjectSettings} from '@revideo/core';
 import {
   Color,
-  Project,
-  RenderVideoUserProjectSettings,
   Renderer,
   Vector2,
   getFullRenderingSettings,

--- a/packages/renderer/server/render-video.ts
+++ b/packages/renderer/server/render-video.ts
@@ -1,9 +1,9 @@
-import {
+import type {
   FfmpegExporterOptions,
   RenderVideoUserProjectSettings,
 } from '@revideo/core';
+import type {FfmpegSettings} from '@revideo/ffmpeg';
 import {
-  FfmpegSettings,
   audioCodecs,
   concatenateMedia,
   createSilentAudioFile,
@@ -17,8 +17,10 @@ import motionCanvas from '@revideo/vite-plugin';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import puppeteer, {Browser, PuppeteerLaunchOptions} from 'puppeteer';
-import {InlineConfig, ServerOptions, ViteDevServer, createServer} from 'vite';
+import type {Browser, PuppeteerLaunchOptions} from 'puppeteer';
+import puppeteer from 'puppeteer';
+import type {InlineConfig, ServerOptions, ViteDevServer} from 'vite';
+import {createServer} from 'vite';
 import {rendererPlugin} from './renderer-plugin';
 import {getParamDefaultsAndCheckValidity} from './validate-settings';
 

--- a/packages/renderer/server/renderer-plugin.ts
+++ b/packages/renderer/server/renderer-plugin.ts
@@ -1,8 +1,9 @@
-import {RenderVideoUserProjectSettings} from '@revideo/core';
-import {FfmpegSettings, ffmpegSettings} from '@revideo/ffmpeg';
+import type {RenderVideoUserProjectSettings} from '@revideo/core';
+import type {FfmpegSettings} from '@revideo/ffmpeg';
+import {ffmpegSettings} from '@revideo/ffmpeg';
 import * as fs from 'fs';
 import * as path from 'path';
-import {Plugin} from 'vite';
+import type {Plugin} from 'vite';
 
 const RendererPath = path.resolve(__dirname, '../renderer.html');
 const Content = fs.readFileSync(RendererPath, 'utf-8');

--- a/packages/renderer/server/validate-settings.ts
+++ b/packages/renderer/server/validate-settings.ts
@@ -1,4 +1,4 @@
-import {FfmpegExporterOptions} from '@revideo/core';
+import type {FfmpegExporterOptions} from '@revideo/core';
 import type {RenderSettings} from 'render-video';
 import {v4 as uuidv4} from 'uuid';
 

--- a/packages/ui/src/components/console/Log.tsx
+++ b/packages/ui/src/components/console/Log.tsx
@@ -1,11 +1,13 @@
 import styles from './Console.module.scss';
 
-import {LogLevel, LogPayload} from '@revideo/core';
+import type {LogPayload} from '@revideo/core';
+import {LogLevel} from '@revideo/core';
 import clsx from 'clsx';
 import {useEffect, useMemo, useState} from 'preact/hooks';
 import {useApplication} from '../../contexts';
 import {useFormattedNumber} from '../../hooks';
-import {StackTraceEntry, resolveStackTrace} from '../../utils';
+import type {StackTraceEntry} from '../../utils';
+import {resolveStackTrace} from '../../utils';
 import {IconButton, Toggle} from '../controls';
 import {Locate} from '../icons';
 import {Collapse} from '../layout';

--- a/packages/ui/src/components/console/SourceCodeFrame.tsx
+++ b/packages/ui/src/components/console/SourceCodeFrame.tsx
@@ -1,11 +1,8 @@
 import styles from './Console.module.scss';
 
 import {useMemo} from 'preact/hooks';
-import {
-  getSourceCodeFrame,
-  openFileInEditor,
-  StackTraceEntry,
-} from '../../utils';
+import type {StackTraceEntry} from '../../utils';
+import {getSourceCodeFrame, openFileInEditor} from '../../utils';
 
 import {IconButton} from '../controls';
 import {OpenInNew} from '../icons';

--- a/packages/ui/src/components/console/StackTrace.tsx
+++ b/packages/ui/src/components/console/StackTrace.tsx
@@ -1,7 +1,8 @@
 import styles from './Console.module.scss';
 
 import clsx from 'clsx';
-import {openFileInEditor, StackTraceEntry} from '../../utils';
+import type {StackTraceEntry} from '../../utils';
+import {openFileInEditor} from '../../utils';
 
 export interface StackTraceProps {
   entries: StackTraceEntry[];

--- a/packages/ui/src/components/controls/ButtonCheckbox.tsx
+++ b/packages/ui/src/components/controls/ButtonCheckbox.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
-import {Button, ButtonProps} from './Button';
+import type {ButtonProps} from './Button';
+import {Button} from './Button';
 import styles from './Controls.module.scss';
 
 export interface ButtonCheckboxProps extends ButtonProps {

--- a/packages/ui/src/components/controls/ButtonSelect.tsx
+++ b/packages/ui/src/components/controls/ButtonSelect.tsx
@@ -1,6 +1,8 @@
-import {Button, ButtonProps} from './Button';
+import type {ButtonProps} from './Button';
+import {Button} from './Button';
 import styles from './Controls.module.scss';
-import {Select, SelectProps} from './Select';
+import type {SelectProps} from './Select';
+import {Select} from './Select';
 
 export type ButtonSelectProps<T> = Omit<ButtonProps, 'value' | 'onChange'> &
   SelectProps<T>;

--- a/packages/ui/src/components/controls/IconButton.tsx
+++ b/packages/ui/src/components/controls/IconButton.tsx
@@ -1,7 +1,7 @@
 import styles from './Controls.module.scss';
 
 import clsx from 'clsx';
-import {ComponentChildren} from 'preact';
+import type {ComponentChildren} from 'preact';
 
 interface IconButtonProps {
   title?: string;

--- a/packages/ui/src/components/controls/IconCheckbox.tsx
+++ b/packages/ui/src/components/controls/IconCheckbox.tsx
@@ -1,7 +1,7 @@
 import styles from './Controls.module.scss';
 
 import clsx from 'clsx';
-import {ComponentChildren} from 'preact';
+import type {ComponentChildren} from 'preact';
 import {IconButton} from './IconButton';
 
 interface IconCheckboxProps {

--- a/packages/ui/src/components/controls/InputSelect.tsx
+++ b/packages/ui/src/components/controls/InputSelect.tsx
@@ -1,7 +1,8 @@
 import type {JSX} from 'preact';
 import styles from './Controls.module.scss';
 import {Input} from './Input';
-import {Select, SelectProps} from './Select';
+import type {SelectProps} from './Select';
+import {Select} from './Select';
 
 export type InputSelectProps<T> = Omit<
   JSX.HTMLAttributes<HTMLInputElement>,

--- a/packages/ui/src/components/controls/NumberInputSelect.tsx
+++ b/packages/ui/src/components/controls/NumberInputSelect.tsx
@@ -1,7 +1,8 @@
 import type {JSX} from 'preact';
 import styles from './Controls.module.scss';
 import {NumberInput} from './NumberInput';
-import {Select, SelectProps} from './Select';
+import type {SelectProps} from './Select';
+import {Select} from './Select';
 
 export type NumberInputSelectProps = Omit<
   JSX.HTMLAttributes<HTMLInputElement>,

--- a/packages/ui/src/components/controls/Pill.tsx
+++ b/packages/ui/src/components/controls/Pill.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import {ComponentChildren} from 'preact';
+import type {ComponentChildren} from 'preact';
 import styles from './Controls.module.scss';
 
 export interface PillProps {

--- a/packages/ui/src/components/controls/Toggle.tsx
+++ b/packages/ui/src/components/controls/Toggle.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import {JSX} from 'preact';
+import type {JSX} from 'preact';
 import {ChevronRight} from '../icons/ChevronRight';
 import styles from './Controls.module.scss';
 

--- a/packages/ui/src/components/fields/AutoField.tsx
+++ b/packages/ui/src/components/fields/AutoField.tsx
@@ -1,5 +1,5 @@
 import {Spacing, Vector2, isType} from '@revideo/core';
-import {FunctionComponent} from 'preact';
+import type {FunctionComponent} from 'preact';
 import {ArrayField} from './ArrayField';
 import {NumberField} from './NumberField';
 import {SpacingField} from './SpacingField';

--- a/packages/ui/src/components/fields/Expandable.tsx
+++ b/packages/ui/src/components/fields/Expandable.tsx
@@ -1,4 +1,4 @@
-import {ComponentChildren} from 'preact';
+import type {ComponentChildren} from 'preact';
 
 import {useStorage} from '../../hooks';
 import {Toggle} from '../controls';

--- a/packages/ui/src/components/fields/Layout.tsx
+++ b/packages/ui/src/components/fields/Layout.tsx
@@ -1,7 +1,7 @@
 import styles from './Layout.module.scss';
 
 import clsx from 'clsx';
-import {ComponentChildren, JSX} from 'preact';
+import type {ComponentChildren, JSX} from 'preact';
 import {useRef, useState} from 'preact/hooks';
 import {useFormattedNumber} from '../../hooks';
 import {Toggle} from '../controls';

--- a/packages/ui/src/components/fields/SpacingField.tsx
+++ b/packages/ui/src/components/fields/SpacingField.tsx
@@ -1,4 +1,4 @@
-import {Spacing} from '@revideo/core';
+import type {Spacing} from '@revideo/core';
 import {Field, FieldSet, FieldValue, NumericField} from './Layout';
 
 export interface SpacingFieldProps {

--- a/packages/ui/src/components/fields/Vector2Field.tsx
+++ b/packages/ui/src/components/fields/Vector2Field.tsx
@@ -1,4 +1,4 @@
-import {Vector2} from '@revideo/core';
+import type {Vector2} from '@revideo/core';
 import {useFormattedNumber} from '../../hooks';
 import {Field, FieldSet, FieldValue, NumericField} from './Layout';
 

--- a/packages/ui/src/components/icons/Add.tsx
+++ b/packages/ui/src/components/icons/Add.tsx
@@ -1,4 +1,4 @@
-import {HTMLAttributes} from 'preact/compat';
+import type {HTMLAttributes} from 'preact/compat';
 
 export function Add(props: HTMLAttributes<SVGSVGElement>) {
   return (

--- a/packages/ui/src/components/icons/ChevronRight.tsx
+++ b/packages/ui/src/components/icons/ChevronRight.tsx
@@ -1,4 +1,4 @@
-import {HTMLAttributes} from 'preact/compat';
+import type {HTMLAttributes} from 'preact/compat';
 
 export function ChevronRight(props: HTMLAttributes<SVGSVGElement>) {
   return (

--- a/packages/ui/src/components/icons/DragIndicator.tsx
+++ b/packages/ui/src/components/icons/DragIndicator.tsx
@@ -1,4 +1,4 @@
-import {HTMLAttributes} from 'preact/compat';
+import type {HTMLAttributes} from 'preact/compat';
 
 export function DragIndicator(props: HTMLAttributes<SVGSVGElement>) {
   return (

--- a/packages/ui/src/components/layout/Collapse.tsx
+++ b/packages/ui/src/components/layout/Collapse.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import {ComponentChildren, JSX} from 'preact';
+import type {ComponentChildren, JSX} from 'preact';
 import {useEffect, useLayoutEffect, useRef, useState} from 'preact/hooks';
 import {useReducedMotion} from '../../hooks';
 import styles from './Collapse.module.scss';

--- a/packages/ui/src/components/layout/ElementSwitch.tsx
+++ b/packages/ui/src/components/layout/ElementSwitch.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'preact';
 import {useMemo} from 'preact/hooks';
 import {usePanels} from '../../contexts';
-import {PluginTabConfig} from '../../plugin';
+import type {PluginTabConfig} from '../../plugin';
 
 export interface ElementSwitchProps<T extends string> {
   value: T;

--- a/packages/ui/src/components/layout/ResizeableLayout.tsx
+++ b/packages/ui/src/components/layout/ResizeableLayout.tsx
@@ -1,8 +1,8 @@
 import styles from './ResizeableLayout.module.scss';
 
-import {Signal} from '@preact/signals';
+import type {Signal} from '@preact/signals';
 import clsx from 'clsx';
-import {ComponentChild} from 'preact';
+import type {ComponentChild} from 'preact';
 import {useRef} from 'preact/hooks';
 import {useStorage} from '../../hooks';
 import {clamp} from '../../utils';

--- a/packages/ui/src/components/playback/CurrentTime.tsx
+++ b/packages/ui/src/components/playback/CurrentTime.tsx
@@ -1,4 +1,4 @@
-import {VNode} from 'preact';
+import type {VNode} from 'preact';
 import {usePlayerTime} from '../../hooks';
 
 interface CurrentTimeProps {

--- a/packages/ui/src/components/playback/Framerate.tsx
+++ b/packages/ui/src/components/playback/Framerate.tsx
@@ -1,4 +1,4 @@
-import {VNode} from 'preact';
+import type {VNode} from 'preact';
 import {useMemo, useRef} from 'preact/hooks';
 import {usePlayerState, usePlayerTime} from '../../hooks';
 

--- a/packages/ui/src/components/tabs/Badge.tsx
+++ b/packages/ui/src/components/tabs/Badge.tsx
@@ -1,6 +1,6 @@
 import {LogLevel} from '@revideo/core';
 import clsx from 'clsx';
-import {ComponentChildren, Ref} from 'preact';
+import type {ComponentChildren, Ref} from 'preact';
 import styles from './Tabs.module.scss';
 
 export interface BadgeInterface {

--- a/packages/ui/src/components/tabs/Pane.tsx
+++ b/packages/ui/src/components/tabs/Pane.tsx
@@ -1,4 +1,4 @@
-import {ComponentChildren, JSX} from 'preact';
+import type {ComponentChildren, JSX} from 'preact';
 import {Header} from '../layout';
 import styles from './Tabs.module.scss';
 

--- a/packages/ui/src/components/tabs/Tabs.tsx
+++ b/packages/ui/src/components/tabs/Tabs.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
-import {ComponentChildren, Ref, createContext, type JSX} from 'preact';
+import type {ComponentChildren, Ref} from 'preact';
+import {createContext, type JSX} from 'preact';
 import {useContext} from 'preact/hooks';
 import styles from './Tabs.module.scss';
 

--- a/packages/ui/src/components/timeline/Playhead.tsx
+++ b/packages/ui/src/components/timeline/Playhead.tsx
@@ -1,6 +1,6 @@
 import styles from './Timeline.module.scss';
 
-import {Signal} from '@preact/signals';
+import type {Signal} from '@preact/signals';
 import {useTimelineContext} from '../../contexts';
 import {usePlayerState, usePlayerTime} from '../../hooks';
 

--- a/packages/ui/src/components/timeline/RangeSelector.tsx
+++ b/packages/ui/src/components/timeline/RangeSelector.tsx
@@ -1,6 +1,6 @@
 import styles from './Timeline.module.scss';
 
-import {RefObject} from 'preact';
+import type {RefObject} from 'preact';
 import {useApplication, useTimelineContext} from '../../contexts';
 import {useDuration, useSharedSettings} from '../../hooks';
 

--- a/packages/ui/src/components/timeline/SlideTrack.tsx
+++ b/packages/ui/src/components/timeline/SlideTrack.tsx
@@ -1,4 +1,4 @@
-import {Scene} from '@revideo/core';
+import type {Scene} from '@revideo/core';
 import clsx from 'clsx';
 import {useApplication} from '../../contexts';
 import {useSubscribableValue} from '../../hooks';

--- a/packages/ui/src/components/timeline/Timeline.tsx
+++ b/packages/ui/src/components/timeline/Timeline.tsx
@@ -3,11 +3,8 @@ import styles from './Timeline.module.scss';
 import {useSignal, useSignalEffect} from '@preact/signals';
 import clsx from 'clsx';
 import {useLayoutEffect, useMemo, useRef} from 'preact/hooks';
-import {
-  TimelineContextProvider,
-  TimelineState,
-  useApplication,
-} from '../../contexts';
+import type {TimelineState} from '../../contexts';
+import {TimelineContextProvider, useApplication} from '../../contexts';
 import {
   useDocumentEvent,
   useDuration,

--- a/packages/ui/src/components/viewport/EditorPreview.tsx
+++ b/packages/ui/src/components/viewport/EditorPreview.tsx
@@ -1,7 +1,8 @@
 import clsx from 'clsx';
-import {ComponentChildren} from 'preact';
+import type {ComponentChildren} from 'preact';
 import {useCallback, useMemo, useRef} from 'preact/hooks';
-import {ViewportProvider, ViewportState, useApplication} from '../../contexts';
+import type {ViewportState} from '../../contexts';
+import {ViewportProvider, useApplication} from '../../contexts';
 import {
   useDocumentEvent,
   useDrag,

--- a/packages/ui/src/components/viewport/Inspector.tsx
+++ b/packages/ui/src/components/viewport/Inspector.tsx
@@ -1,6 +1,6 @@
 import {useSignal, useSignalEffect} from '@preact/signals';
 import clsx from 'clsx';
-import {FunctionComponent} from 'preact';
+import type {FunctionComponent} from 'preact';
 import {useEffect, useMemo, useRef} from 'preact/hooks';
 import {useApplication, usePanels} from '../../contexts';
 import {useReducedMotion} from '../../hooks';

--- a/packages/ui/src/components/viewport/OverlayCanvas.tsx
+++ b/packages/ui/src/components/viewport/OverlayCanvas.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
-import {JSX} from 'preact';
+import type {JSX} from 'preact';
 import {useLayoutEffect, useRef, useState} from 'preact/hooks';
 import {useApplication} from '../../contexts';
 import {useSubscribable, useViewportMatrix} from '../../hooks';
-import {PluginDrawFunction} from '../../plugin';
+import type {PluginDrawFunction} from '../../plugin';
 import styles from './Viewport.module.scss';
 
 interface OverlayCanvasProps extends JSX.HTMLAttributes<HTMLCanvasElement> {

--- a/packages/ui/src/components/viewport/PreviewStage.tsx
+++ b/packages/ui/src/components/viewport/PreviewStage.tsx
@@ -1,5 +1,5 @@
 import {Stage} from '@revideo/core';
-import {JSX} from 'preact';
+import type {JSX} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 import {useApplication} from '../../contexts';
 import {

--- a/packages/ui/src/components/viewport/StageView.tsx
+++ b/packages/ui/src/components/viewport/StageView.tsx
@@ -1,7 +1,8 @@
 import type {Stage} from '@revideo/core';
 import clsx from 'clsx';
-import {JSX} from 'preact';
-import {MutableRef, useLayoutEffect, useRef} from 'preact/hooks';
+import type {JSX} from 'preact';
+import type {MutableRef} from 'preact/hooks';
+import {useLayoutEffect, useRef} from 'preact/hooks';
 import {useSharedSettings} from '../../hooks';
 import styles from './Viewport.module.scss';
 

--- a/packages/ui/src/components/viewport/Timestamp.tsx
+++ b/packages/ui/src/components/viewport/Timestamp.tsx
@@ -1,4 +1,4 @@
-import {JSX} from 'preact';
+import type {JSX} from 'preact';
 import {useApplication} from '../../contexts';
 import {usePlayerState} from '../../hooks';
 import {formatDuration} from '../../utils';

--- a/packages/ui/src/contexts/application.tsx
+++ b/packages/ui/src/contexts/application.tsx
@@ -1,9 +1,11 @@
-import {Signal, useSignal} from '@preact/signals';
+import type {Signal} from '@preact/signals';
+import {useSignal} from '@preact/signals';
 import type {Player, Project, Renderer} from '@revideo/core';
-import {ComponentChildren, createContext} from 'preact';
+import type {ComponentChildren} from 'preact';
+import {createContext} from 'preact';
 import {useContext, useRef} from 'preact/hooks';
 import {useSubscribable} from '../hooks';
-import {EditorPlugin} from '../plugin';
+import type {EditorPlugin} from '../plugin';
 import {LoggerManager} from '../utils';
 
 export interface Inspection {

--- a/packages/ui/src/contexts/panels.tsx
+++ b/packages/ui/src/contexts/panels.tsx
@@ -1,7 +1,9 @@
-import {computed, ReadonlySignal} from '@preact/signals';
-import {ComponentChildren, createContext} from 'preact';
+import type {ReadonlySignal} from '@preact/signals';
+import {computed} from '@preact/signals';
+import type {ComponentChildren} from 'preact';
+import {createContext} from 'preact';
 import {useContext, useMemo} from 'preact/hooks';
-import {PluginInspectorConfig, PluginTabConfig} from '../plugin';
+import type {PluginInspectorConfig, PluginTabConfig} from '../plugin';
 import {EditorPanel, storedSignal} from '../signals';
 import {useApplication} from './application';
 

--- a/packages/ui/src/contexts/shortcuts.tsx
+++ b/packages/ui/src/contexts/shortcuts.tsx
@@ -1,4 +1,5 @@
-import {ComponentChildren, createContext} from 'preact';
+import type {ComponentChildren} from 'preact';
+import {createContext} from 'preact';
 import {useContext, useState} from 'preact/hooks';
 
 export type Shortcut = {

--- a/packages/ui/src/contexts/timeline.tsx
+++ b/packages/ui/src/contexts/timeline.tsx
@@ -1,4 +1,5 @@
-import {ComponentChildren, createContext} from 'preact';
+import type {ComponentChildren} from 'preact';
+import {createContext} from 'preact';
 import {useContext} from 'preact/hooks';
 
 export interface TimelineState {

--- a/packages/ui/src/hooks/useHover.ts
+++ b/packages/ui/src/hooks/useHover.ts
@@ -1,4 +1,5 @@
-import React, {useEffect, useRef, useState} from 'react';
+import type React from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 type UseHoverType<T extends HTMLElement> = [React.RefObject<T>, boolean];
 

--- a/packages/ui/src/hooks/useShortcut.ts
+++ b/packages/ui/src/hooks/useShortcut.ts
@@ -1,4 +1,5 @@
-import {ShortcutModules, useShortcuts} from '../contexts/shortcuts';
+import type {ShortcutModules} from '../contexts/shortcuts';
+import {useShortcuts} from '../contexts/shortcuts';
 import {useHover} from './useHover';
 
 type UseHoverType<T extends HTMLElement> = [React.RefObject<T>, boolean];

--- a/packages/ui/src/hooks/useSize.tsx
+++ b/packages/ui/src/hooks/useSize.tsx
@@ -1,4 +1,5 @@
-import {MutableRef, useEffect, useMemo, useState} from 'preact/hooks';
+import type {MutableRef} from 'preact/hooks';
+import {useEffect, useMemo, useState} from 'preact/hooks';
 
 export function useSize<T extends Element>(
   ref: MutableRef<T>,

--- a/packages/ui/src/hooks/useStateChange.ts
+++ b/packages/ui/src/hooks/useStateChange.ts
@@ -1,4 +1,5 @@
-import {Inputs, useLayoutEffect, useRef} from 'preact/hooks';
+import type {Inputs} from 'preact/hooks';
+import {useLayoutEffect, useRef} from 'preact/hooks';
 
 export function useStateChange<T extends Inputs>(
   onChange: (prev: T) => void,

--- a/packages/ui/src/hooks/useSubscribable.ts
+++ b/packages/ui/src/hooks/useSubscribable.ts
@@ -3,7 +3,8 @@ import type {
   Subscribable,
   SubscribableValueEvent,
 } from '@revideo/core';
-import {Inputs, useEffect, useState} from 'preact/hooks';
+import type {Inputs} from 'preact/hooks';
+import {useEffect, useState} from 'preact/hooks';
 
 export function useSubscribable<TValue, THandler extends EventHandler<TValue>>(
   event: Subscribable<TValue, THandler>,

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -7,9 +7,11 @@ import {
   getFullPreviewSettings,
   type Project,
 } from '@revideo/core';
-import {ComponentChild, render} from 'preact';
+import type {ComponentChild} from 'preact';
+import {render} from 'preact';
 import {Editor} from './Editor';
-import {ProjectData, ProjectSelection} from './ProjectSelection';
+import type {ProjectData} from './ProjectSelection';
+import {ProjectSelection} from './ProjectSelection';
 import {ApplicationProvider, PanelsProvider} from './contexts';
 import {ShortcutsProvider} from './contexts/shortcuts';
 import GridPlugin from './plugin/GridPlugin';

--- a/packages/ui/src/plugin/EditorPlugin.ts
+++ b/packages/ui/src/plugin/EditorPlugin.ts
@@ -1,5 +1,5 @@
-import {Plugin} from '@revideo/core';
-import {FunctionComponent} from 'preact';
+import type {Plugin} from '@revideo/core';
+import type {FunctionComponent} from 'preact';
 
 /**
  * Properties passed to the {@link PluginTabConfig.tabComponent} and

--- a/packages/ui/src/signals/storedSignal.ts
+++ b/packages/ui/src/signals/storedSignal.ts
@@ -1,4 +1,5 @@
-import {Signal, useSignal, useSignalEffect} from '@preact/signals';
+import type {Signal} from '@preact/signals';
+import {useSignal, useSignalEffect} from '@preact/signals';
 import {projectNameSignal} from './projectName';
 
 export function storedSignal<T>(

--- a/packages/ui/src/utils/LoggerManager.ts
+++ b/packages/ui/src/utils/LoggerManager.ts
@@ -1,10 +1,5 @@
-import {
-  EventDispatcher,
-  LogLevel,
-  LogPayload,
-  Logger,
-  ValueDispatcher,
-} from '@revideo/core';
+import type {LogPayload, Logger} from '@revideo/core';
+import {EventDispatcher, LogLevel, ValueDispatcher} from '@revideo/core';
 
 export class LoggerManager {
   public get onInspected() {

--- a/packages/vite-plugin/src/main.ts
+++ b/packages/vite-plugin/src/main.ts
@@ -13,7 +13,8 @@ import {
   wasmExporterPlugin,
   webglPlugin,
 } from './partials';
-import {PLUGIN_OPTIONS, PluginOptions, isPlugin} from './plugins';
+import type {PluginOptions} from './plugins';
+import {PLUGIN_OPTIONS, isPlugin} from './plugins';
 import {getProjects} from './utils';
 
 export interface MotionCanvasPluginConfig {

--- a/packages/vite-plugin/src/partials/assets.ts
+++ b/packages/vite-plugin/src/partials/assets.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import {Readable} from 'stream';
-import {ModuleNode, Plugin, ResolvedConfig} from 'vite';
+import type {ModuleNode, Plugin, ResolvedConfig} from 'vite';
 
 const AUDIO_EXTENSION_REGEX = /\.(mp3|wav|ogg|aac|flac)(?:$|\?)/;
 const AUDIO_HMR_DELAY = 1000;

--- a/packages/vite-plugin/src/partials/editor.ts
+++ b/packages/vite-plugin/src/partials/editor.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import {Plugin} from 'vite';
-import {Projects} from '../utils';
+import type {Plugin} from 'vite';
+import type {Projects} from '../utils';
 
 interface EditorPluginConfig {
   editor: string;

--- a/packages/vite-plugin/src/partials/ffmpegBridge.ts
+++ b/packages/vite-plugin/src/partials/ffmpegBridge.ts
@@ -1,6 +1,6 @@
+import type {FFmpegExporterSettings} from '@revideo/ffmpeg';
 import {
   FFmpegExporterServer,
-  FFmpegExporterSettings,
   VideoFrameExtractor,
   generateAudio,
   mergeMedia,

--- a/packages/vite-plugin/src/partials/imageExporter.ts
+++ b/packages/vite-plugin/src/partials/imageExporter.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import mime from 'mime-types';
 import path from 'path';
-import {Plugin} from 'vite';
+import type {Plugin} from 'vite';
 import {openInExplorer} from '../openInExplorer';
 
 interface ExporterPluginConfig {

--- a/packages/vite-plugin/src/partials/meta.ts
+++ b/packages/vite-plugin/src/partials/meta.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import {Plugin, ResolvedConfig} from 'vite';
+import type {Plugin, ResolvedConfig} from 'vite';
 
 export function metaPlugin(): Plugin {
   const timeStamps: Record<string, number> = {};

--- a/packages/vite-plugin/src/partials/metrics.ts
+++ b/packages/vite-plugin/src/partials/metrics.ts
@@ -1,5 +1,5 @@
 import {EventName, sendEvent} from '@revideo/telemetry';
-import {Plugin} from 'vite';
+import type {Plugin} from 'vite';
 
 export function metricsPlugin(): Plugin {
   return {

--- a/packages/vite-plugin/src/partials/projects.ts
+++ b/packages/vite-plugin/src/partials/projects.ts
@@ -1,6 +1,6 @@
-import {Plugin} from 'vite';
-import {PluginOptions} from '../plugins';
-import {Projects} from '../utils';
+import type {Plugin} from 'vite';
+import type {PluginOptions} from '../plugins';
+import type {Projects} from '../utils';
 // import {getVersions} from '../versions';
 
 interface ProjectPluginConfig {

--- a/packages/vite-plugin/src/partials/rive.ts
+++ b/packages/vite-plugin/src/partials/rive.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import path from 'path';
 import {Readable} from 'stream';
-import {Plugin} from 'vite';
+import type {Plugin} from 'vite';
 
 async function getRiveWasmPath() {
   try {

--- a/packages/vite-plugin/src/partials/settings.ts
+++ b/packages/vite-plugin/src/partials/settings.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import {Plugin} from 'vite';
+import type {Plugin} from 'vite';
 
 export function settingsPlugin(): Plugin {
   const settingsId = 'virtual:settings.meta';

--- a/packages/vite-plugin/src/partials/wasmExporter.ts
+++ b/packages/vite-plugin/src/partials/wasmExporter.ts
@@ -1,9 +1,10 @@
-import formidable, {IncomingForm} from 'formidable';
+import type formidable from 'formidable';
+import {IncomingForm} from 'formidable';
 import * as fs from 'fs';
 import * as os from 'os';
 import path from 'path';
 import {Readable} from 'stream';
-import {Plugin} from 'vite';
+import type {Plugin} from 'vite';
 
 export function wasmExporterPlugin(): Plugin {
   return {

--- a/packages/vite-plugin/src/partials/webgl.ts
+++ b/packages/vite-plugin/src/partials/webgl.ts
@@ -1,7 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import {SourceNode} from 'source-map';
-import {normalizePath, Plugin, ResolvedConfig} from 'vite';
+import type {Plugin, ResolvedConfig} from 'vite';
+import {normalizePath} from 'vite';
 
 declare module 'source-map' {
   interface SourceNode {

--- a/packages/vite-plugin/src/plugins.ts
+++ b/packages/vite-plugin/src/plugins.ts
@@ -1,4 +1,4 @@
-import {Plugin as VitePlugin} from 'vite';
+import type {Plugin as VitePlugin} from 'vite';
 
 /**
  * Represents a Revideo project configured in the Vite plugin.

--- a/packages/vite-plugin/src/utils.ts
+++ b/packages/vite-plugin/src/utils.ts
@@ -1,7 +1,7 @@
 import fg from 'fast-glob';
 import fs from 'fs';
 import path from 'path';
-import {ProjectData} from './plugins';
+import type {ProjectData} from './plugins';
 
 export interface Projects {
   list: ProjectData[];


### PR DESCRIPTION
I'm trying to hunt down all of the circular imports we have. As a part of that I made type imports mandatory and auto-fixed all the instances where stuff was imported as a value even though only the type is needed.