### PR TITLE
Fix: Handle query parameters in m3u8 URL validation

### DIFF
--- a/packages/2d/src/lib/components/Video.ts
+++ b/packages/2d/src/lib/components/Video.ts
@@ -113,7 +113,8 @@ export class Video extends Media {
       video = document.createElement('video');
       video.crossOrigin = 'anonymous';
 
-      if (src.endsWith('.m3u8')) {
+      const parsedSrc = new URL(src);
+      if (parsedSrc.pathname.endsWith('.m3u8')) {
         const hls = new Hls();
         hls.loadSource(src);
         hls.attachMedia(video);


### PR DESCRIPTION
This pull request addresses a bug in the URL validation logic for m3u8 video sources. Previously, the code checked if the URL ended with ".m3u8" without considering query parameters, which caused valid URLs like /manifest.m3u8?parameter=2 to be incorrectly rejected.