### PR TITLE
fix: restore relative url support for video nodes

### DIFF
--- a/packages/2d/src/lib/components/Video.ts
+++ b/packages/2d/src/lib/components/Video.ts
@@ -113,7 +113,7 @@ export class Video extends Media {
       video = document.createElement('video');
       video.crossOrigin = 'anonymous';
 
-      const parsedSrc = new URL(src);
+      const parsedSrc = new URL(src, window.location.origin);
       if (parsedSrc.pathname.endsWith('.m3u8')) {
         const hls = new Hls();
         hls.loadSource(src);


### PR DESCRIPTION

This pull request addresses an issue introduced in a [previous fix](https://github.com/redotvideo/revideo/pull/335) preventing the use of relative urls in `<Video>` nodes.

The bug occurs because the value of `src` is now passed to the `URL()` constructor.
It works well when the path is absolute however as described in the [URL API specifications](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) a second `base` argument containing the base of the url is required when using a relative path.

The `base` argument will be ignored if a `<Video>` node is provided with an absolute url so both absolute & relative paths should work fine.

resolves #338 