### PR TITLE
fix: use track.timescale and not movie.timescale

### DIFF
--- a/packages/2d/src/lib/utils/video/parser/parser.ts
+++ b/packages/2d/src/lib/utils/video/parser/parser.ts
@@ -57,7 +57,7 @@ async function getFileInfo(uri: string) {
       const edits = editsWithoutFps.map(edit => {
         const trackDurationInSec = track.duration / track.timescale;
         const segmentDurationInSec =
-          edit.segmentDuration / track.movie_timescale;
+          edit.segmentDuration / track.timescale;
         const segmentFrames =
           track.nb_samples * (segmentDurationInSec / trackDurationInSec);
         const mediaRate =
@@ -209,7 +209,7 @@ export class Mp4Parser {
   private getSecondDurationOfSegment(edit: Edit) {
     const mediaRate = edit.mediaRateInteger + edit.mediaRateFraction / 0xffff;
     const duration =
-      edit.segmentDuration / this.file.getInfo().videoTracks[0].movie_timescale;
+      edit.segmentDuration / this.file.getInfo().videoTracks[0].timescale;
     return duration / mediaRate;
   }
 

--- a/packages/2d/src/lib/utils/video/parser/segment.ts
+++ b/packages/2d/src/lib/utils/video/parser/segment.ts
@@ -59,7 +59,7 @@ export class Segment {
 
       const segmentDurationInSeconds =
         this.edit.segmentDuration /
-        this.file.getInfo().videoTracks[0].movie_timescale;
+        this.file.getInfo().videoTracks[0].timescale;
       const framesToFill = Math.ceil(segmentDurationInSeconds * this.edit.fps);
 
       const height = this.file.getInfo().videoTracks[0].track_height;
@@ -224,7 +224,7 @@ export class Segment {
     // Check if we are past the segment duration.
     const segmentDurationInSec =
       this.edit.segmentDuration /
-      this.file.getInfo().videoTracks[0].movie_timescale;
+      this.file.getInfo().videoTracks[0].timescale;
     const segmentEndTime = mediaTimeInSec + segmentDurationInSec;
     if (frameTimeInSec > segmentEndTime) {
       frame.close();


### PR DESCRIPTION
# Description
Hi! Thank you for making this short renderer!

I was trying it with several videos, and I found a little bug. In some places, we are working with different timescales, which can cause a mismatch in timestamps of the rendering of the video leading to this error in the `parser.ts`:
```
Timestamp 1242.6843333333334 is outside of the video, max timestamp is 1060.4583333333333
```

This is because the movie timescales, in some videos, can be taken from the Audio, and not the video. Here we have an example:
```
ffprobe -loglevel quiet -i little_error_video.mp4 -show_format -show_streams | grep time_base
time_base=1/50000 --> track.timescale
time_base=1/48000 --> track.movie_timescale

ffprobe -loglevel quiet -i huge_error_video.mp4 -show_format -show_streams | grep time_base
time_base=1/25000 --> track.timescale
time_base=1/48000 --> track.movie_timescale
```

Or you can see it directly in the debug, looking at the timescale of the track and the movie_timescale of the track, which should be working with the same number:
```
:claqueta: [BACKEND] MP4 PARSER DEBUG
parser.ts:33 :gráfico_de_barras: Track Info: {duration: 74934000, timescale: 25000, movie_timescale: 48000, nb_samples: 74934, duration_sec: '2997.360', …}duration: 74934000duration_min: "50.0"duration_sec: "2997.360"movie_timescale: 48000nb_samples: 74934timescale: 25000[[Prototype]]: Object
parser.ts:42 :lápiz2: Edit Lists: {hasEdits: false, editCount: 0}
parser.ts:99 :ábaco: [BACKEND] Edit 0 FPS Calculation: {trackDurationInSec: '2997.360', segDur_CURRENT: '1561.125000', segDur_FIXED: '2997.360000', mediaRate: '1.000000', fps_CURRENT: '25.000', …}fps_CURRENT: "25.000"fps_FIXED: "25.000"isProblematic: falsemediaRate: "1.000000"segDur_CURRENT: "1561.125000"segDur_FIXED: "2997.360000"trackDurationInSec: "2997.360"[[Prototype]]: Object
parser.ts:112 :dardo: [BACKEND] Final edits created: 1
```

Thank you for contributing to the open-source community!