### PR TITLE
chore: remove committed .next artifact and gitignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules
 /packages/*/build
 /packages/*/output
 /packages/*/.next
+/.next
 
 .rollup.cache
 *.tsbuildinfo

--- a/.next/trace
+++ b/.next/trace
@@ -1,1 +1,0 @@
-[{"name":"next-dev","duration":247395,"timestamp":3094115341714,"id":1,"tags":{},"startTime":1783026780794,"traceId":"12bad73261fa69d9"}]


### PR DESCRIPTION
The `.next/trace` build artifact was accidentally committed in the docs rebuild PR. This removes it from the repo and adds `/.next` to the root `.gitignore` so the top-level Next.js build output stays untracked going forward.