### PR TITLE
ci: use npm OIDC trusted publishing for releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,10 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write # Required for npm OIDC trusted publishing
     env:
-      NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
-      NPM_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
       GH_TOKEN: ${{secrets.PUBLISH_TOKEN}}
     steps:
       - uses: actions/checkout@v4
@@ -41,6 +42,8 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
           cache: npm
+      # Trusted publishing requires npm >= 11.5.1; Node 22 ships npm 10.x
+      - run: npm install -g npm@latest
       - run: git config --global user.email "167322027+revideo-bot@users.noreply.github.com"
       - run: git config --global user.name "revideo-bot"
       - run: npm ci


### PR DESCRIPTION
## What

Switches the release workflow from a long-lived npm token to npm's [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers/).

- Adds `id-token: write` permission (the OIDC token npm verifies)
- Removes `NODE_AUTH_TOKEN` / `NPM_TOKEN` env vars
- Upgrades npm to `latest` in CI — trusted publishing needs npm ≥ 11.5.1, but Node 22 ships npm 10.x

Lerna is already `^9.0.7`, and v9+ performs the OIDC exchange automatically, so the `lerna publish` commands are unchanged. This also emits provenance attestations for free.

## Required manual step before merging is useful

Trusted publishers are configured **per package on npmjs.com**. For each publishable package (`@revideo/core`, `@revideo/2d`, `@revideo/cli`, `@revideo/create`, `@revideo/ffmpeg`, `@revideo/player`, `@revideo/player-react`, `@revideo/renderer`, `@revideo/telemetry`, `@revideo/ui`, `@revideo/vite-plugin`):

npmjs.com → package → Settings → Trusted Publisher → GitHub Actions:
- Repository: `midrender/revideo`
- Workflow filename: `publish.yml`
- Environment: (blank)

The `NPM_AUTH_TOKEN` secret can be deleted after the first successful trusted-publish run.

## Notes

- Renaming `publish.yml` will break publishing until every package's trusted-publisher config is updated.
- Local publishing still requires a token.