### PR TITLE
fix: correct package.json repository URLs for provenance (havenhq → midrender)

### DIFF
--- a/packages/2d/package.json
+++ b/packages/2d/package.json
@@ -4,7 +4,7 @@
   "description": "A 2D renderer for revideo",
   "author": "revideo",
   "homepage": "https://re.video/",
-  "bugs": "https://github.com/havenhq/revideo/issues",
+  "bugs": "https://github.com/midrender/revideo/issues",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",
@@ -19,7 +19,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/havenhq/revideo.git"
+    "url": "git+https://github.com/midrender/revideo.git"
   },
   "files": [
     "lib",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,8 +5,13 @@
   "main": "dist/index.js",
   "author": "revideo",
   "homepage": "https://re.video/",
-  "bugs": "https://github.com/havenhq/revideo/issues",
+  "bugs": "https://github.com/midrender/revideo/issues",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/midrender/revideo.git",
+    "directory": "packages/cli"
+  },
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "author": "revideo",
   "homepage": "https://re.video/",
-  "bugs": "https://github.com/havenhq/revideo/issues",
+  "bugs": "https://github.com/midrender/revideo/issues",
   "license": "MIT",
   "scripts": {
     "dev": "tsc -p tsconfig.build.json -w",
@@ -16,7 +16,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/havenhq/revideo.git"
+    "url": "https://github.com/midrender/revideo.git"
   },
   "files": [
     "lib",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "author": "revideo",
   "homepage": "https://re.video/",
-  "bugs": "https://github.com/havenhq/revideo/issues",
+  "bugs": "https://github.com/midrender/revideo/issues",
   "license": "MIT",
   "type": "module",
   "bin": {
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/havenhq/revideo.git"
+    "url": "https://github.com/midrender/revideo.git"
   },
   "devDependencies": {
     "@revideo/2d": "0.10.4",

--- a/packages/ffmpeg/package.json
+++ b/packages/ffmpeg/package.json
@@ -5,8 +5,13 @@
   "main": "dist/index.js",
   "author": "revideo",
   "homepage": "https://re.video/",
-  "bugs": "https://github.com/havenhq/revideo/issues",
+  "bugs": "https://github.com/midrender/revideo/issues",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/midrender/revideo.git",
+    "directory": "packages/ffmpeg"
+  },
   "scripts": {
     "build": "tsc"
   },

--- a/packages/player-react/package.json
+++ b/packages/player-react/package.json
@@ -12,6 +12,11 @@
   "keywords": [],
   "author": "revideo",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/midrender/revideo.git",
+    "directory": "packages/player-react"
+  },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.2",
     "@types/react": "^19",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -6,7 +6,7 @@
   "types": "types/main.d.ts",
   "author": "revideo",
   "homepage": "https://re.video/",
-  "bugs": "https://github.com/havenhq/revideo/issues",
+  "bugs": "https://github.com/midrender/revideo/issues",
   "license": "MIT",
   "type": "module",
   "scripts": {
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/havenhq/revideo.git"
+    "url": "https://github.com/midrender/revideo.git"
   },
   "files": [
     "dist",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -5,8 +5,13 @@
   "main": "lib/server/index.js",
   "author": "revideo",
   "homepage": "https://re.video/",
-  "bugs": "https://github.com/havenhq/revideo/issues",
+  "bugs": "https://github.com/midrender/revideo/issues",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/midrender/revideo.git",
+    "directory": "packages/renderer"
+  },
   "scripts": {
     "build": "npm run client:build && npm run server:build",
     "postbuild": "ncp renderer.html lib/renderer.html",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "author": "revideo",
   "homepage": "https://re.video/",
-  "bugs": "https://github.com/havenhq/revideo/issues",
+  "bugs": "https://github.com/midrender/revideo/issues",
   "license": "MIT",
   "scripts": {
     "dev": "tsc -w",
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/havenhq/revideo.git"
+    "url": "git+https://github.com/midrender/revideo.git"
   },
   "files": [
     "dist",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,7 @@
   "types": "dist/main.d.ts",
   "author": "revideo",
   "homepage": "https://re.video/",
-  "bugs": "https://github.com/havenhq/revideo/issues",
+  "bugs": "https://github.com/midrender/revideo/issues",
   "license": "MIT",
   "type": "module",
   "scripts": {
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/havenhq/revideo.git"
+    "url": "https://github.com/midrender/revideo.git"
   },
   "files": [
     "dist",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "author": "revideo",
   "homepage": "https://re.video/",
-  "bugs": "https://github.com/havenhq/revideo/issues",
+  "bugs": "https://github.com/midrender/revideo/issues",
   "license": "MIT",
   "scripts": {
     "dev": "tsc -w",
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/havenhq/revideo.git"
+    "url": "git+https://github.com/midrender/revideo.git"
   },
   "files": [
     "lib"


### PR DESCRIPTION
## Why

The first OIDC canary release ([run 29057736194](https://github.com/midrender/revideo/actions/runs/29057736194)) failed at the publish step. Trusted publishing worked (OIDC token + provenance were generated), but npm **rejected the provenance** because the package manifests still point at the old org:

```
E422 Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "git+https://github.com/havenhq/revideo.git",
expected to match "https://github.com/midrender/revideo" from provenance
```

npm provenance requires `repository.url` to match the repo the build actually ran in (`midrender/revideo`).

## What

- Rewrite all `repository.url` and `bugs` URLs from `havenhq/revideo` → `midrender/revideo`.
- Add a `repository` field to `cli`, `ffmpeg`, `renderer`, and `player-react`, which had none (would also block provenance).

All 11 publishable packages now resolve to `https://github.com/midrender/revideo.git`.

## After merge

Re-run **Publish Packages to NPM** (releaseType `canary`) — the publish step should now pass provenance verification.