### PR TITLE
fix: decouple editor plugin injection from core so headless renders work

### DIFF
--- a/packages/core/src/app/makeProject.ts
+++ b/packages/core/src/app/makeProject.ts
@@ -62,19 +62,10 @@ export function makeProject(project: UserProject): Project {
     settings: convertedSettings,
     plugins: [],
     logger: new Logger(),
-    versions: createVersionObject('0.10.4'),
-  };
-}
-
-export async function addEditorToProject(project: Project) {
-  const url = '/@id/@revideo/2d/editor';
-  const imported = await import(
-    /* webpackIgnore: true */ /* @vite-ignore */ url
-  );
-  const plugin = imported.default();
-
-  return {
-    ...project,
-    plugins: [...project.plugins, plugin],
+    // Placeholder only. The real, per-package versions are resolved from the
+    // installed `package.json` files and injected by the vite-plugin's editor
+    // entry (the sole consumer, the editor footer). They are never used during
+    // a headless render, so we don't try to resolve them here in core.
+    versions: createVersionObject('0.0.0'),
   };
 }

--- a/packages/template/tsconfig.json
+++ b/packages/template/tsconfig.json
@@ -5,7 +5,8 @@
     "noEmit": false,
     "outDir": "dist",
     "rootDir": "./src",
-    "module": "CommonJS",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "skipLibCheck": true
   },
   "include": ["src"]

--- a/packages/vite-plugin/src/partials/editor.ts
+++ b/packages/vite-plugin/src/partials/editor.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import type {Plugin} from 'vite';
 import type {Projects} from '../utils';
+import {getVersions} from '../versions';
 
 interface EditorPluginConfig {
   editor: string;
@@ -19,6 +20,43 @@ export function editorPlugin({editor, projects}: EditorPluginConfig): Plugin {
 
   const resolvedEditorId = '\0virtual:editor';
 
+  /**
+   * Generate the editor entry module for a single project.
+   *
+   * Editor plugins are declared per-scene as module specifiers (e.g.
+   * `'@revideo/2d/editor'`). We load them here, in the dev-server-only entry,
+   * and inject them into the project before handing it to the editor. This
+   * keeps the dynamic import — and the Vite-internal `/@id/` prefix used to
+   * resolve it — out of `@revideo/core`, so it never leaks into a headless
+   * render bundle.
+   *
+   * The real package versions (resolved from the installed `package.json`
+   * files) are injected here too — they're only ever shown in the editor
+   * footer, so this is the one place that has both the project and access to
+   * the file system.
+   */
+  const editorEntry = (projectUrl: string) => {
+    const versions = JSON.stringify(getVersions());
+    /* language=typescript */
+    return `\
+import {editor} from '${editor}';
+import project from '/@fs/${path.resolve(projectUrl)}';
+const specifiers = [
+  ...new Set((project.scenes ?? []).flatMap(scene => scene.plugins ?? [])),
+];
+const plugins = await Promise.all(
+  specifiers.map(specifier =>
+    import(/* @vite-ignore */ '/@id/' + specifier).then(mod => mod.default()),
+  ),
+);
+editor({
+  ...project,
+  versions: ${versions},
+  plugins: [...project.plugins, ...plugins],
+});
+`;
+  };
+
   return {
     name: 'revideo:editor',
 
@@ -27,26 +65,14 @@ export function editorPlugin({editor, projects}: EditorPluginConfig): Plugin {
 
       if (id.startsWith(resolvedEditorId)) {
         if (projects.list.length === 1) {
-          /* language=typescript */
-          return `\
-import {editor} from '${editor}';
-import project from '/@fs/${path.resolve(projects.list[0].url)}';
-import {addEditorToProject} from '@revideo/core';
-editor(await addEditorToProject(project));
-`;
+          return editorEntry(projects.list[0].url);
         }
 
         if (query) {
           const params = new URLSearchParams(query);
           const name = params.get('project');
           if (name && projects.lookup.has(name)) {
-            /* language=typescript */
-            return `\
-import {editor} from '${editor}';
-import project from '/@fs/${path.resolve(projects.lookup.get(name)!.url)}';
-import {addEditorToProject} from '@revideo/core';
-editor(await addEditorToProject(project));
-`;
+            return editorEntry(projects.lookup.get(name)!.url);
           }
         }
 

--- a/packages/vite-plugin/src/versions.ts
+++ b/packages/vite-plugin/src/versions.ts
@@ -6,7 +6,7 @@ export function getVersions() {
     core: loadVersion('@revideo/core'),
     two: loadVersion('@revideo/2d'),
     ui: loadVersion('@revideo/ui'),
-    vitePlugin: loadVersion('..'),
+    vitePlugin: loadVersion('@revideo/vite-plugin'),
   };
 }
 


### PR DESCRIPTION
## Problem

On a canary-scaffolded project, `npm run render` hangs and never produces a video.

Root cause: `makeProject`'s `addEditorToProject()` baked a **Vite dev-server-internal URL** (`/@id/@revideo/2d/editor`) into `@revideo/core`. Every project — including headless renders — imports core, so that string rides into the render bundle. The renderer bundles its own **Vite 8**, whose `import-analysis` rejects the unresolvable `/@id/` id in the optimized core dep, wedging the render page (Puppeteer then waits forever). It didn't surface before because the editor runs on the project's Vite 4.5, which tolerated it.

## Fix

- **core** — remove `addEditorToProject` and its hardcoded `/@id/` dynamic import. Core no longer contains any Vite-internal string, so nothing leaks into a render bundle.
- **vite-plugin** — inject editor plugins in the dev-only editor entry instead, driven by each scene's declared plugin specifiers (`scene.plugins`, the mechanism `Project.plugins`' own JSDoc documents). The `/@id/` URL is now constructed here, where it belongs.
- **vite-plugin** — while instantiating the project for the editor, also inject the real per-package versions via the previously-commented-out `getVersions()`, replacing core's hardcoded `createVersionObject('0.10.4')` (the editor footer is the only consumer; versions are never used in a render). Also fixed `getVersions` so the vite-plugin's own version resolves (`'..'` → `'@revideo/vite-plugin'`).
- **template** — set `moduleResolution` alongside `module: CommonJS` so the render tsconfig compiles (the base now ships `bundler`, which conflicts → TS5095).

## Validation (all under the renderer's Vite 8)

- **Render**: `npm run template:render` now produces `output/video.mp4` (2.0 MB); previously it hung on the `/@id/@revideo/2d/editor` `import-analysis` error.
- **Editor**: dev server (Vite 8) — the generated entry emits the new code, `/@id/@revideo/2d/editor` resolves `200` (real plugin module), and the footer now shows real versions instead of a hardcoded `0.10.4`.
- core / vite-plugin / renderer build clean; prettier + eslint pass.

## Related

- The user-facing scaffolding templates need the same `moduleResolution` fix; that's a companion PR in the examples repo: midrender/examples#29.
- The submodule pointer bump for that fix is intentionally **not** in this PR — it should follow once #29 merges, to avoid pinning an unmerged SHA.