### PR TITLE
fix: declare axios (cli) and uuid (renderer) as dependencies

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,6 +33,7 @@
     "@revideo/renderer": "0.10.4",
     "@revideo/telemetry": "0.10.4",
     "@revideo/vite-plugin": "0.10.4",
+    "axios": "^1.16.0",
     "commander": "^15.0.0",
     "cors": "^2.8.5",
     "express": "^5.2.1",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@revideo/ffmpeg": "0.10.4",
     "puppeteer": "^25.3.0",
+    "uuid": "^14.0.1",
     "vite": "^8.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

On the canary getting-started flow, `npm run start` (`revideo editor`) crashes immediately:

```
Error: Cannot find module 'axios'
  ... @revideo/cli/dist/server/render.js:8
```

## Cause

Two long-standing **phantom dependencies** that only ever resolved via hoisting inside this monorepo:

- **`axios`** — `@revideo/cli`'s render server (`src/server/render.ts`) has imported it for webhook callbacks since #82 (May 2024). It was never declared; it only resolved because `lerna → nx` pulls `axios` into the root `node_modules`. A consumer install has no `axios`, so loading the CLI (which eagerly imports the render server) throws.
- **`uuid`** — `@revideo/renderer`'s `server/validate-settings.ts` imports it but never declared it; it resolves only because `@revideo/ffmpeg` hoists `uuid`. Latent breakage if that ever changes.

The canary's updated dep tree stopped providing `axios` transitively, which is why it surfaced now.

## Fix

- `@revideo/cli`: add `"axios": "^1.16.0"`
- `@revideo/renderer`: add `"uuid": "^14.0.1"` (matches ffmpeg/cli)

## Validation

Reproduced on a clean canary (`0.10.5-alpha.1138`) install. With `axios` present, `revideo editor` boots and serves **HTTP 200**. Ran a phantom-dependency audit across all node-executed packages; `axios` and `uuid` were the only genuine consumer-facing runtime misses (remaining flags are type-only imports, tsconfig path aliases, test-only devDeps, or pre-bundled editor/ui build deps).

## Note

`@revideo/cli` also imports `createServer` from `vite` at runtime; it's always satisfied by the project's own `vite`, and declaring it here would introduce a third pinned `vite` amid the existing 4.5-vs-8 skew, so it's intentionally left alone.