### PR TITLE
chore: release 0.11.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
   "private": false,
-  "version": "0.10.4",
+  "version": "0.11.0",
   "ignoreChanges": ["**/*.test.ts", "**/*.md"],
   "message": "ci(release): %v [skip ci]",
   "conventionalCommits": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4172,7 +4172,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
@@ -4214,7 +4213,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4235,7 +4233,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4256,7 +4253,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4277,7 +4273,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4298,7 +4293,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4319,7 +4313,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4340,7 +4333,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4361,7 +4353,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4382,7 +4373,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4403,7 +4393,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4424,7 +4413,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4445,7 +4433,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4466,7 +4453,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -7691,14 +7677,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/axios": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
       "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -8813,7 +8797,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -10751,7 +10734,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -11178,7 +11160,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12226,7 +12207,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
       "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -12607,37 +12587,6 @@
       },
       "funding": {
         "url": "https://ko-fi.com/dangreen"
-      }
-    },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-filter": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
-      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/git-raw-commits/node_modules/meow": {
@@ -13066,7 +13015,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -17166,7 +17114,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -17176,7 +17123,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -17776,8 +17722,7 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/node-gyp": {
       "version": "12.4.0",
@@ -20318,7 +20263,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -25343,13 +25287,13 @@
     },
     "packages/2d": {
       "name": "@revideo/2d",
-      "version": "0.10.4",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.10.1",
         "@lezer/common": "^1.2.1",
         "@lezer/highlight": "^1.2.0",
-        "@revideo/core": "0.10.4",
+        "@revideo/core": "0.11.0",
         "@rive-app/canvas-advanced": "2.7.3",
         "code-fns": "^0.8.2",
         "hls.js": "^1.5.11",
@@ -25359,7 +25303,7 @@
       },
       "devDependencies": {
         "@preact/signals": "^2.9.2",
-        "@revideo/ui": "0.10.4",
+        "@revideo/ui": "0.11.0",
         "@rollup/plugin-commonjs": "^28.0.9",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-terser": "^0.4.4",
@@ -25373,12 +25317,13 @@
     },
     "packages/cli": {
       "name": "@revideo/cli",
-      "version": "0.10.4",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@revideo/renderer": "0.10.4",
-        "@revideo/telemetry": "0.10.4",
-        "@revideo/vite-plugin": "0.10.4",
+        "@revideo/renderer": "0.11.0",
+        "@revideo/telemetry": "0.11.0",
+        "@revideo/vite-plugin": "0.11.0",
+        "axios": "^1.16.0",
         "commander": "^15.0.0",
         "cors": "^2.8.5",
         "express": "^5.2.1",
@@ -25395,7 +25340,7 @@
     },
     "packages/core": {
       "name": "@revideo/core",
-      "version": "0.10.4",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "culori": "^4.0.1",
@@ -25413,10 +25358,10 @@
     },
     "packages/create": {
       "name": "@revideo/create",
-      "version": "0.10.4",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@revideo/telemetry": "0.10.4",
+        "@revideo/telemetry": "0.11.0",
         "minimist": "^1.2.8",
         "prompts": "^2.4.2"
       },
@@ -25424,12 +25369,12 @@
         "create-revideo": "index.js"
       },
       "devDependencies": {
-        "@revideo/2d": "0.10.4",
-        "@revideo/core": "0.10.4",
-        "@revideo/ffmpeg": "0.10.4",
-        "@revideo/renderer": "0.10.4",
-        "@revideo/ui": "0.10.4",
-        "@revideo/vite-plugin": "0.10.4"
+        "@revideo/2d": "0.11.0",
+        "@revideo/core": "0.11.0",
+        "@revideo/ffmpeg": "0.11.0",
+        "@revideo/renderer": "0.11.0",
+        "@revideo/ui": "0.11.0",
+        "@revideo/vite-plugin": "0.11.0"
       }
     },
     "packages/docs": {
@@ -25480,7 +25425,10 @@
     },
     "packages/docs-redirect": {
       "name": "@revideo/docs-redirect",
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "packages/docs/node_modules/@types/node": {
       "version": "22.13.10",
@@ -25529,13 +25477,13 @@
     },
     "packages/ffmpeg": {
       "name": "@revideo/ffmpeg",
-      "version": "0.10.4",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "@ffprobe-installer/ffprobe": "^2.0.0",
-        "@revideo/core": "0.10.4",
-        "@revideo/telemetry": "0.10.4",
+        "@revideo/core": "0.11.0",
+        "@revideo/telemetry": "0.11.0",
         "fluent-ffmpeg": "^2.1.2",
         "uuid": "^14.0.1"
       },
@@ -25547,20 +25495,20 @@
     },
     "packages/player": {
       "name": "@revideo/player",
-      "version": "0.10.4",
+      "version": "0.11.0",
       "license": "MIT",
       "devDependencies": {
-        "@revideo/core": "0.10.4",
+        "@revideo/core": "0.11.0",
         "sass": "^1.58.0",
         "terser": "^5.16.1"
       }
     },
     "packages/player-react": {
       "name": "@revideo/player-react",
-      "version": "0.10.4",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@revideo/core": "0.10.4",
+        "@revideo/core": "0.11.0",
         "react": "^19",
         "react-dom": "^19",
         "uuid": "^14.0.1"
@@ -25577,21 +25525,22 @@
     },
     "packages/renderer": {
       "name": "@revideo/renderer",
-      "version": "0.10.4",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@revideo/ffmpeg": "0.10.4",
+        "@revideo/ffmpeg": "0.11.0",
         "puppeteer": "^25.3.0",
+        "uuid": "^14.0.1",
         "vite": "^8.1.2"
       },
       "devDependencies": {
-        "@revideo/core": "0.10.4",
+        "@revideo/core": "0.11.0",
         "ncp": "^2.0.0"
       }
     },
     "packages/telemetry": {
       "name": "@revideo/telemetry",
-      "version": "0.10.4",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -25616,11 +25565,11 @@
     },
     "packages/ui": {
       "name": "@revideo/ui",
-      "version": "0.10.4",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@preact/signals": "^2.9.2",
-        "@revideo/core": "0.10.4",
+        "@revideo/core": "0.11.0",
         "preact": "^10.19.2"
       },
       "devDependencies": {
@@ -25634,10 +25583,10 @@
     },
     "packages/vite-plugin": {
       "name": "@revideo/vite-plugin",
-      "version": "0.10.4",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@revideo/ffmpeg": "0.10.4",
+        "@revideo/ffmpeg": "0.11.0",
         "fast-glob": "^3.3.1",
         "follow-redirects": "^1.15.2",
         "formidable": "^3.5.1",
@@ -25645,7 +25594,7 @@
         "source-map": "^0.7.6"
       },
       "devDependencies": {
-        "@revideo/telemetry": "0.10.4",
+        "@revideo/telemetry": "0.11.0",
         "@types/follow-redirects": "^1.14.1",
         "@types/formidable": "^3.4.5",
         "@types/mime-types": "^3.0.1"

--- a/packages/2d/package.json
+++ b/packages/2d/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/2d",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "A 2D renderer for revideo",
   "author": "revideo",
   "homepage": "https://re.video/",
@@ -29,7 +29,7 @@
   ],
   "devDependencies": {
     "@preact/signals": "^2.9.2",
-    "@revideo/ui": "0.10.4",
+    "@revideo/ui": "0.11.0",
     "@rollup/plugin-commonjs": "^28.0.9",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-terser": "^0.4.4",
@@ -44,7 +44,7 @@
     "@codemirror/language": "^6.10.1",
     "@lezer/common": "^1.2.1",
     "@lezer/highlight": "^1.2.0",
-    "@revideo/core": "0.10.4",
+    "@revideo/core": "0.11.0",
     "@rive-app/canvas-advanced": "2.7.3",
     "code-fns": "^0.8.2",
     "hls.js": "^1.5.11",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/cli",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "A CLI for revideo",
   "main": "dist/index.js",
   "author": "revideo",
@@ -30,9 +30,9 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
-    "@revideo/renderer": "0.10.4",
-    "@revideo/telemetry": "0.10.4",
-    "@revideo/vite-plugin": "0.10.4",
+    "@revideo/renderer": "0.11.0",
+    "@revideo/telemetry": "0.11.0",
+    "@revideo/vite-plugin": "0.11.0",
     "axios": "^1.16.0",
     "commander": "^15.0.0",
     "cors": "^2.8.5",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,7 +7,7 @@ import {createServer} from './server/index';
 
 const program = new Command();
 
-const VERSION = '0.10.4';
+const VERSION = '0.11.0';
 
 program
   .name('revideo')

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/core",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "A web-based framework for creating videos programmatically",
   "main": "lib/index.js",
   "author": "revideo",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/create",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "Quickly scaffold revideo projects",
   "main": "index.js",
   "author": "revideo",
@@ -20,15 +20,15 @@
     "url": "https://github.com/midrender/revideo.git"
   },
   "devDependencies": {
-    "@revideo/2d": "0.10.4",
-    "@revideo/core": "0.10.4",
-    "@revideo/ffmpeg": "0.10.4",
-    "@revideo/renderer": "0.10.4",
-    "@revideo/ui": "0.10.4",
-    "@revideo/vite-plugin": "0.10.4"
+    "@revideo/2d": "0.11.0",
+    "@revideo/core": "0.11.0",
+    "@revideo/ffmpeg": "0.11.0",
+    "@revideo/renderer": "0.11.0",
+    "@revideo/ui": "0.11.0",
+    "@revideo/vite-plugin": "0.11.0"
   },
   "dependencies": {
-    "@revideo/telemetry": "0.10.4",
+    "@revideo/telemetry": "0.11.0",
     "minimist": "^1.2.8",
     "prompts": "^2.4.2"
   }

--- a/packages/ffmpeg/package.json
+++ b/packages/ffmpeg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/ffmpeg",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "Ffmpeg utilities for revideo",
   "main": "dist/index.js",
   "author": "revideo",
@@ -22,8 +22,8 @@
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@ffprobe-installer/ffprobe": "^2.0.0",
-    "@revideo/core": "0.10.4",
-    "@revideo/telemetry": "0.10.4",
+    "@revideo/core": "0.11.0",
+    "@revideo/telemetry": "0.11.0",
     "fluent-ffmpeg": "^2.1.2",
     "uuid": "^14.0.1"
   },

--- a/packages/player-react/package.json
+++ b/packages/player-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/player-react",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "",
   "main": "dist/index.js",
   "files": [
@@ -27,7 +27,7 @@
     "tailwindcss": "^4.3.2"
   },
   "dependencies": {
-    "@revideo/core": "0.10.4",
+    "@revideo/core": "0.11.0",
     "react": "^19",
     "react-dom": "^19",
     "uuid": "^14.0.1"

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/player",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "A custom element for displaying animations made with revideo",
   "main": "dist/main.js",
   "types": "types/main.d.ts",
@@ -22,7 +22,7 @@
     "types"
   ],
   "devDependencies": {
-    "@revideo/core": "0.10.4",
+    "@revideo/core": "0.11.0",
     "sass": "^1.58.0",
     "terser": "^5.16.1"
   }

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/renderer",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "A headless renderer for revideo",
   "main": "lib/server/index.js",
   "author": "revideo",
@@ -25,13 +25,13 @@
     "types"
   ],
   "dependencies": {
-    "@revideo/ffmpeg": "0.10.4",
+    "@revideo/ffmpeg": "0.11.0",
     "puppeteer": "^25.3.0",
     "uuid": "^14.0.1",
     "vite": "^8.1.2"
   },
   "devDependencies": {
-    "@revideo/core": "0.10.4",
+    "@revideo/core": "0.11.0",
     "ncp": "^2.0.0"
   }
 }

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/telemetry",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "Telemetry for Revideo. Check the documentation to learn how to disable it.",
   "main": "dist/index.js",
   "author": "revideo",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/ui",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "A visual editor for revideo",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "@preact/signals": "^2.9.2",
-    "@revideo/core": "0.10.4",
+    "@revideo/core": "0.11.0",
     "preact": "^10.19.2"
   },
   "devDependencies": {

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/vite-plugin",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "A Vite plugin for revideo projects",
   "main": "lib/index.js",
   "author": "revideo",
@@ -19,13 +19,13 @@
     "lib"
   ],
   "devDependencies": {
-    "@revideo/telemetry": "0.10.4",
+    "@revideo/telemetry": "0.11.0",
     "@types/follow-redirects": "^1.14.1",
     "@types/formidable": "^3.4.5",
     "@types/mime-types": "^3.0.1"
   },
   "dependencies": {
-    "@revideo/ffmpeg": "0.10.4",
+    "@revideo/ffmpeg": "0.11.0",
     "fast-glob": "^3.3.1",
     "follow-redirects": "^1.15.2",
     "formidable": "^3.5.1",


### PR DESCRIPTION
Release 0.11.0.

- `chore: prepare release 0.11.0` — bump examples submodule to `release-0.11.0` (@revideo deps → 0.11.0) and CLI `VERSION` string.
- `ci(release): 0.11.0 [skip ci]` — lerna version bump across all packages + lockfile (pushed by the release workflow).

Published to npm with OIDC provenance; `@revideo/*@latest` is now 0.11.0 and tag `v0.11.0` is created.